### PR TITLE
perf(reconciler): rebuild ConfigMaps per target instead of globally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,7 @@ ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
   [ -n "$$v" ] || { echo "Set ENVTEST_K8S_VERSION manually (k8s.io/api replace has no tag)" >&2; exit 1; }; \
   printf '%s\n' "$$v" | sed -E 's/^v?[0-9]+\.([0-9]+).*/1.\1/')
 
-GOLANGCI_LINT_VERSION ?= v2.5.0
+GOLANGCI_LINT_VERSION ?= v2.11.4
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)

--- a/api/v1alpha1/customhttproute_types.go
+++ b/api/v1alpha1/customhttproute_types.go
@@ -311,7 +311,7 @@ type Rule struct {
 	// matches defines the conditions for matching this rule
 	// +required
 	// +kubebuilder:validation:MinItems=1
-	// +kubebuilder:validation:MaxItems=50
+	// +kubebuilder:validation:MaxItems=128
 	Matches []PathMatch `json:"matches"`
 
 	// actions defines transformations to apply to matched requests
@@ -356,7 +356,7 @@ type CustomHTTPRouteSpec struct {
 	// hostnames is a list of hostnames that this route applies to
 	// +required
 	// +kubebuilder:validation:MinItems=1
-	// +kubebuilder:validation:MaxItems=50
+	// +kubebuilder:validation:MaxItems=128
 	Hostnames []string `json:"hostnames"`
 
 	// pathPrefixes defines prefixes to prepend to paths (e.g., language prefixes)

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: customrouter
 description: A Helm chart for CustomRouter - Kubernetes operator and external processor for dynamic HTTP routing
 type: application
-version: 0.5.1
-appVersion: "0.5.1"
+version: 0.5.2
+appVersion: "0.5.2"
 kubeVersion: ">= 1.26.0-0"
 keywords:
   - kubernetes

--- a/chart/crds/customrouter.freepik.com_customhttproutes.yaml
+++ b/chart/crds/customrouter.freepik.com_customhttproutes.yaml
@@ -98,7 +98,7 @@ spec:
                   to
                 items:
                   type: string
-                maxItems: 50
+                maxItems: 128
                 minItems: 1
                 type: array
               pathPrefixes:
@@ -363,7 +363,7 @@ spec:
                         required:
                         - path
                         type: object
-                      maxItems: 50
+                      maxItems: 128
                       minItems: 1
                       type: array
                     pathPrefixes:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -68,6 +68,7 @@ func main() {
 	var secureMetrics bool
 	var enableHTTP2 bool
 	var routesConfigMapNamespace string
+	var maxConcurrentReconciles int
 	var enableWebhooks bool
 	var webhookConfigName string
 	var webhookServiceName string
@@ -92,6 +93,8 @@ func main() {
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
 	flag.StringVar(&routesConfigMapNamespace, "routes-configmap-namespace", "default",
 		"The namespace where route ConfigMaps will be stored")
+	flag.IntVar(&maxConcurrentReconciles, "max-concurrent-reconciles", 5,
+		"Maximum number of concurrent reconciliations for CustomHTTPRoute controller")
 	flag.BoolVar(&enableWebhooks, "enable-webhooks", false,
 		"Enable validating admission webhooks for hostname conflict detection")
 	flag.StringVar(&webhookConfigName, "webhook-config-name", "",
@@ -243,9 +246,10 @@ func main() {
 	}
 
 	if err := (&customhttproute.CustomHTTPRouteReconciler{
-		Client:             mgr.GetClient(),
-		Scheme:             mgr.GetScheme(),
-		ConfigMapNamespace: routesConfigMapNamespace,
+		Client:                  mgr.GetClient(),
+		Scheme:                  mgr.GetScheme(),
+		ConfigMapNamespace:      routesConfigMapNamespace,
+		MaxConcurrentReconciles: maxConcurrentReconciles,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "CustomHTTPRoute")
 		os.Exit(1)

--- a/config/operator/deploy/crd/bases/customrouter.freepik.com_customhttproutes.yaml
+++ b/config/operator/deploy/crd/bases/customrouter.freepik.com_customhttproutes.yaml
@@ -98,7 +98,7 @@ spec:
                   to
                 items:
                   type: string
-                maxItems: 50
+                maxItems: 128
                 minItems: 1
                 type: array
               pathPrefixes:
@@ -363,7 +363,7 @@ spec:
                         required:
                         - path
                         type: object
-                      maxItems: 50
+                      maxItems: 128
                       minItems: 1
                       type: array
                     pathPrefixes:

--- a/internal/controller/customhttproute/controller.go
+++ b/internal/controller/customhttproute/controller.go
@@ -18,6 +18,7 @@ package customhttproute
 
 import (
 	"context"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -25,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -34,11 +36,14 @@ import (
 	"github.com/freepik-company/customrouter/internal/controller"
 )
 
+const targetRefIndexField = ".spec.targetRef.name"
+
 // CustomHTTPRouteReconciler reconciles a CustomHTTPRoute object
 type CustomHTTPRouteReconciler struct {
 	client.Client
-	Scheme             *runtime.Scheme
-	ConfigMapNamespace string
+	Scheme                  *runtime.Scheme
+	ConfigMapNamespace      string
+	MaxConcurrentReconciles int
 }
 
 // +kubebuilder:rbac:groups=customrouter.freepik.com,resources=customhttproutes,verbs=get;list;watch;create;update;patch;delete
@@ -139,9 +144,27 @@ func (r *CustomHTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *CustomHTTPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := mgr.GetFieldIndexer().IndexField(
+		context.Background(),
+		&crv1alpha1.CustomHTTPRoute{},
+		targetRefIndexField,
+		func(obj client.Object) []string {
+			route := obj.(*crv1alpha1.CustomHTTPRoute)
+			return []string{route.Spec.TargetRef.Name}
+		},
+	); err != nil {
+		return fmt.Errorf("failed to create field indexer for %s: %w", targetRefIndexField, err)
+	}
+
+	maxConcurrent := r.MaxConcurrentReconciles
+	if maxConcurrent <= 0 {
+		maxConcurrent = 1
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&crv1alpha1.CustomHTTPRoute{}).
 		Watches(&corev1.Service{}, handler.EnqueueRequestsFromMapFunc(r.findRoutesForService)).
+		WithOptions(ctrlcontroller.Options{MaxConcurrentReconciles: maxConcurrent}).
 		Named("customhttproute").
 		Complete(r)
 }

--- a/internal/controller/customhttproute/sync.go
+++ b/internal/controller/customhttproute/sync.go
@@ -55,82 +55,122 @@ const (
 
 	// configMapBaseName is the base name for all route ConfigMaps
 	configMapBaseName = "customrouter-routes"
+
+	// routesDataKey is the key used in ConfigMap data for the routes JSON
+	routesDataKey = "routes.json"
+
+	// lastTargetAnnotation tracks the previous targetRef to clean up stale ConfigMaps on target changes
+	lastTargetAnnotation = "customrouter.freepik.com/last-target"
 )
 
 // ReconcileObject handles the reconciliation logic for CustomHTTPRoute resources.
-// It rebuilds the ConfigMaps with all routes whenever a CustomHTTPRoute is created, updated, or deleted.
+// It rebuilds only the ConfigMaps for the affected target, not all targets.
 func (r *CustomHTTPRouteReconciler) ReconcileObject(
 	ctx context.Context,
 	eventType watch.EventType,
 	resourceManifest *v1alpha1.CustomHTTPRoute,
 ) error {
 	logger := log.FromContext(ctx)
+	target := resourceManifest.Spec.TargetRef.Name
 
 	switch eventType {
 	case watch.Modified:
 		logger.Info("CustomHTTPRoute modified, rebuilding routes ConfigMaps",
 			"name", resourceManifest.Name,
 			"namespace", resourceManifest.Namespace,
-			"target", resourceManifest.Spec.TargetRef.Name)
+			"target", target)
 	case watch.Deleted:
 		logger.Info("CustomHTTPRoute deleted, rebuilding routes ConfigMaps",
 			"name", resourceManifest.Name,
 			"namespace", resourceManifest.Namespace,
-			"target", resourceManifest.Spec.TargetRef.Name)
+			"target", target)
 	}
 
-	return r.rebuildAllConfigMaps(ctx)
+	// If the target changed, also rebuild the old target to clean up its stale ConfigMaps
+	if previousTarget, ok := resourceManifest.Annotations[lastTargetAnnotation]; ok && previousTarget != target {
+		logger.Info("Target changed, also rebuilding previous target",
+			"name", resourceManifest.Name,
+			"previousTarget", previousTarget,
+			"newTarget", target)
+		if err := r.rebuildConfigMapsForTarget(ctx, previousTarget); err != nil {
+			return fmt.Errorf("failed to rebuild ConfigMaps for previous target %s: %w", previousTarget, err)
+		}
+	}
+
+	// Update the last-target annotation
+	if err := r.ensureLastTargetAnnotation(ctx, resourceManifest, target); err != nil {
+		logger.Error(err, "failed to update last-target annotation", "name", resourceManifest.Name)
+	}
+
+	// Rebuild ConfigMaps for the current target
+	if err := r.rebuildConfigMapsForTarget(ctx, target); err != nil {
+		return err
+	}
+
+	// Reconcile catch-all EnvoyFilter only if this route has a catchAllRoute configured
+	if resourceManifest.Spec.CatchAllRoute != nil || eventType == watch.Deleted {
+		if err := r.reconcileCatchAllFromAllRoutes(ctx); err != nil {
+			return fmt.Errorf("failed to reconcile catch-all routes: %w", err)
+		}
+	}
+
+	return nil
 }
 
-// rebuildAllConfigMaps fetches all CustomHTTPRoutes, groups them by target, and rebuilds ConfigMaps
-func (r *CustomHTTPRouteReconciler) rebuildAllConfigMaps(ctx context.Context) error {
-	logger := log.FromContext(ctx)
+// ensureLastTargetAnnotation sets the last-target annotation on the resource if not already correct.
+func (r *CustomHTTPRouteReconciler) ensureLastTargetAnnotation(
+	ctx context.Context,
+	resource *v1alpha1.CustomHTTPRoute,
+	target string,
+) error {
+	if resource.Annotations != nil && resource.Annotations[lastTargetAnnotation] == target {
+		return nil
+	}
+	if resource.Annotations == nil {
+		resource.Annotations = make(map[string]string)
+	}
+	resource.Annotations[lastTargetAnnotation] = target
+	return r.Update(ctx, resource)
+}
 
-	// List all CustomHTTPRoutes in the cluster
+// reconcileCatchAllFromAllRoutes lists all routes and reconciles catch-all EnvoyFilters.
+// This is only called when a route with catchAllRoute is modified or any route is deleted.
+func (r *CustomHTTPRouteReconciler) reconcileCatchAllFromAllRoutes(ctx context.Context) error {
 	routeList := &v1alpha1.CustomHTTPRouteList{}
 	if err := r.List(ctx, routeList); err != nil {
-		return fmt.Errorf("failed to list CustomHTTPRoutes: %w", err)
+		return fmt.Errorf("failed to list CustomHTTPRoutes for catch-all reconciliation: %w", err)
+	}
+	return r.reconcileCatchAllFromRoutes(ctx, routeList)
+}
+
+// rebuildConfigMapsForTarget rebuilds ConfigMaps only for a specific target
+func (r *CustomHTTPRouteReconciler) rebuildConfigMapsForTarget(ctx context.Context, target string) error {
+	logger := log.FromContext(ctx)
+
+	// List only CustomHTTPRoutes for this target using the field indexer
+	routeList := &v1alpha1.CustomHTTPRouteList{}
+	if err := r.List(ctx, routeList, client.MatchingFields{
+		targetRefIndexField: target,
+	}); err != nil {
+		return fmt.Errorf("failed to list CustomHTTPRoutes for target %s: %w", target, err)
 	}
 
-	// Group routes by target
-	routesByTarget := make(map[string][]*v1alpha1.CustomHTTPRoute)
+	// Collect active (non-deleting) routes for this target
+	var targetRoutes []*v1alpha1.CustomHTTPRoute
 	for i := range routeList.Items {
 		route := &routeList.Items[i]
-		// Skip routes that are being deleted
-		if !route.DeletionTimestamp.IsZero() {
-			continue
-		}
-		target := route.Spec.TargetRef.Name
-		routesByTarget[target] = append(routesByTarget[target], route)
-	}
-
-	// Track all active ConfigMap names across all targets
-	allActiveNames := make(map[string]bool)
-
-	// Pre-resolve ExternalName services
-	externalNames := make(map[string]string)
-	for _, targetRoutes := range routesByTarget {
-		for _, route := range targetRoutes {
-			for _, rule := range route.Spec.Rules {
-				for _, ref := range rule.BackendRefs {
-					key := ref.Name + "/" + ref.Namespace
-					if _, seen := externalNames[key]; seen {
-						continue
-					}
-					svc := &corev1.Service{}
-					if err := r.Get(ctx, client.ObjectKey{Name: ref.Name, Namespace: ref.Namespace}, svc); err != nil {
-						continue
-					}
-					if svc.Spec.Type == corev1.ServiceTypeExternalName {
-						externalNames[key] = svc.Spec.ExternalName
-					}
-				}
-			}
+		if route.DeletionTimestamp.IsZero() {
+			targetRoutes = append(targetRoutes, route)
 		}
 	}
 
-	// Process each target
-	for target, targetRoutes := range routesByTarget {
+	// Track active ConfigMap names for this target
+	activeNames := make(map[string]bool)
+
+	if len(targetRoutes) > 0 {
+		// Pre-resolve ExternalName services for this target's routes
+		externalNames := r.resolveExternalNames(ctx, targetRoutes)
+
 		// Expand routes from all CustomHTTPRoutes for this target
 		allRoutes := make([]map[string][]routes.Route, 0, len(targetRoutes))
 		for _, route := range targetRoutes {
@@ -156,9 +196,8 @@ func (r *CustomHTTPRouteReconciler) rebuildAllConfigMaps(ctx context.Context) er
 			return fmt.Errorf("failed to upsert ConfigMaps for target %s: %w", target, err)
 		}
 
-		// Track active names
 		for _, p := range partitions {
-			allActiveNames[p.Name] = true
+			activeNames[p.Name] = true
 		}
 
 		logger.Info("ConfigMaps updated successfully",
@@ -168,17 +207,42 @@ func (r *CustomHTTPRouteReconciler) rebuildAllConfigMaps(ctx context.Context) er
 			"partitions", len(partitions))
 	}
 
-	// Delete stale ConfigMaps (from targets that no longer have routes)
-	if err := r.deleteStaleConfigMaps(ctx, allActiveNames); err != nil {
+	// Delete stale ConfigMaps for this target
+	if err := r.deleteStaleConfigMapsForTarget(ctx, target, activeNames); err != nil {
 		return err
 	}
 
-	// Reconcile catch-all EnvoyFilter from aggregated catchAllRoute declarations
-	if err := r.reconcileCatchAllFromRoutes(ctx, routeList); err != nil {
-		return fmt.Errorf("failed to reconcile catch-all routes: %w", err)
-	}
-
 	return nil
+}
+
+// resolveExternalNames pre-resolves ExternalName services referenced by the given routes.
+// Services that are not ExternalName type are marked as seen to avoid redundant lookups.
+func (r *CustomHTTPRouteReconciler) resolveExternalNames(
+	ctx context.Context,
+	targetRoutes []*v1alpha1.CustomHTTPRoute,
+) map[string]string {
+	externalNames := make(map[string]string)
+	seen := make(map[string]bool)
+
+	for _, route := range targetRoutes {
+		for _, rule := range route.Spec.Rules {
+			for _, ref := range rule.BackendRefs {
+				key := ref.Name + "/" + ref.Namespace
+				if seen[key] {
+					continue
+				}
+				seen[key] = true
+				svc := &corev1.Service{}
+				if err := r.Get(ctx, client.ObjectKey{Name: ref.Name, Namespace: ref.Namespace}, svc); err != nil {
+					continue
+				}
+				if svc.Spec.Type == corev1.ServiceTypeExternalName {
+					externalNames[key] = svc.Spec.ExternalName
+				}
+			}
+		}
+	}
+	return externalNames
 }
 
 // partitionConfig splits the routes config into multiple partitions if it exceeds the size limit
@@ -424,7 +488,7 @@ func (r *CustomHTTPRouteReconciler) upsertSingleConfigMap(
 					Labels:    configMapLabels,
 				},
 				Data: map[string]string{
-					"routes.json": partition.Data,
+					routesDataKey: partition.Data,
 				},
 			}
 			return r.Create(ctx, cm)
@@ -434,36 +498,41 @@ func (r *CustomHTTPRouteReconciler) upsertSingleConfigMap(
 			return err
 		}
 
+		// Skip update if content and labels are already correct
+		if existingCM.Data[routesDataKey] == partition.Data &&
+			mapsEqual(existingCM.Labels, configMapLabels) {
+			return nil
+		}
+
 		existingCM.Labels = configMapLabels
 		existingCM.Data = map[string]string{
-			"routes.json": partition.Data,
+			routesDataKey: partition.Data,
 		}
 		return r.Update(ctx, existingCM)
 	})
 }
 
-// deleteStaleConfigMaps removes ConfigMaps that are no longer needed
-func (r *CustomHTTPRouteReconciler) deleteStaleConfigMaps(
+// deleteStaleConfigMapsForTarget removes ConfigMaps for a specific target that are no longer needed
+func (r *CustomHTTPRouteReconciler) deleteStaleConfigMapsForTarget(
 	ctx context.Context,
+	target string,
 	activeNames map[string]bool,
 ) error {
-	// List all ConfigMaps managed by this controller
 	configMapList := &corev1.ConfigMapList{}
 	labelSelector := labels.SelectorFromSet(map[string]string{
 		configMapManagedByLabel: configMapManagedByValue,
+		configMapTargetLabel:   target,
 	})
 
 	if err := r.List(ctx, configMapList, &client.ListOptions{
 		Namespace:     r.ConfigMapNamespace,
 		LabelSelector: labelSelector,
 	}); err != nil {
-		return fmt.Errorf("failed to list ConfigMaps: %w", err)
+		return fmt.Errorf("failed to list ConfigMaps for target %s: %w", target, err)
 	}
 
-	// Delete ConfigMaps that are not in the active set
 	for i := range configMapList.Items {
 		cm := &configMapList.Items[i]
-		// Only delete if it starts with our base name (to avoid deleting unrelated ConfigMaps)
 		if !strings.HasPrefix(cm.Name, configMapBaseName) {
 			continue
 		}
@@ -475,4 +544,17 @@ func (r *CustomHTTPRouteReconciler) deleteStaleConfigMaps(
 	}
 
 	return nil
+}
+
+// mapsEqual returns true if two string maps have identical keys and values.
+func mapsEqual(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/controller/customhttproute/sync.go
+++ b/internal/controller/customhttproute/sync.go
@@ -97,9 +97,9 @@ func (r *CustomHTTPRouteReconciler) ReconcileObject(
 		}
 	}
 
-	// Update the last-target annotation
+	// Update the last-target annotation — must succeed to ensure future target changes are tracked
 	if err := r.ensureLastTargetAnnotation(ctx, resourceManifest, target); err != nil {
-		logger.Error(err, "failed to update last-target annotation", "name", resourceManifest.Name)
+		return fmt.Errorf("failed to update last-target annotation: %w", err)
 	}
 
 	// Rebuild ConfigMaps for the current target
@@ -377,7 +377,7 @@ func (r *CustomHTTPRouteReconciler) splitHostRoutes(
 	var partitions []ConfigMapPartition
 	partIndex := startIndex
 
-	currentRoutes := make([]routes.Route, 0)
+	currentRoutes := make([]routes.Route, 0, len(hostRoutes))
 	currentSize := 0
 	baseSize := len(fmt.Sprintf(`{"version":1,"hosts":{"%s":[]}}`, host))
 
@@ -523,7 +523,7 @@ func (r *CustomHTTPRouteReconciler) deleteStaleConfigMapsForTarget(
 	configMapList := &corev1.ConfigMapList{}
 	labelSelector := labels.SelectorFromSet(map[string]string{
 		configMapManagedByLabel: configMapManagedByValue,
-		configMapTargetLabel:   target,
+		configMapTargetLabel:    target,
 	})
 
 	if err := r.List(ctx, configMapList, &client.ListOptions{

--- a/internal/controller/customhttproute/sync.go
+++ b/internal/controller/customhttproute/sync.go
@@ -476,7 +476,9 @@ func (r *CustomHTTPRouteReconciler) upsertSingleConfigMap(
 		Jitter:   0.2,
 	}
 
-	return retry.RetryOnConflict(backoff, func() error {
+	return retry.OnError(backoff, func(err error) bool {
+		return errors.IsConflict(err) || errors.IsAlreadyExists(err)
+	}, func() error {
 		existingCM := &corev1.ConfigMap{}
 		err := r.Get(ctx, configMapKey, existingCM)
 

--- a/internal/controller/customhttproute/sync.go
+++ b/internal/controller/customhttproute/sync.go
@@ -64,6 +64,9 @@ const (
 
 	// hadCatchAllAnnotation tracks whether the route previously had catchAllRoute configured
 	hadCatchAllAnnotation = "customrouter.freepik.com/had-catch-all"
+
+	// annotationValueTrue is the canonical string value for boolean true annotations
+	annotationValueTrue = "true"
 )
 
 // ReconcileObject handles the reconciliation logic for CustomHTTPRoute resources.
@@ -116,7 +119,7 @@ func (r *CustomHTTPRouteReconciler) ReconcileObject(
 	// - the route currently has catchAllRoute configured
 	// - the route is being deleted (may have had catch-all entries)
 	// - the route previously had catchAllRoute but it was removed (annotation present, field nil)
-	hadCatchAll := resourceManifest.Annotations[hadCatchAllAnnotation] == "true"
+	hadCatchAll := resourceManifest.Annotations[hadCatchAllAnnotation] == annotationValueTrue
 	hasCatchAll := resourceManifest.Spec.CatchAllRoute != nil
 	needsCatchAllReconcile := hasCatchAll || eventType == watch.Deleted || hadCatchAll
 
@@ -170,7 +173,7 @@ func (r *CustomHTTPRouteReconciler) ensureHadCatchAllAnnotation(
 		resource.Annotations = make(map[string]string)
 	}
 	if hasCatchAll {
-		resource.Annotations[hadCatchAllAnnotation] = "true"
+		resource.Annotations[hadCatchAllAnnotation] = annotationValueTrue
 	} else {
 		delete(resource.Annotations, hadCatchAllAnnotation)
 	}

--- a/internal/controller/customhttproute/sync.go
+++ b/internal/controller/customhttproute/sync.go
@@ -61,6 +61,9 @@ const (
 
 	// lastTargetAnnotation tracks the previous targetRef to clean up stale ConfigMaps on target changes
 	lastTargetAnnotation = "customrouter.freepik.com/last-target"
+
+	// hadCatchAllAnnotation tracks whether the route previously had catchAllRoute configured
+	hadCatchAllAnnotation = "customrouter.freepik.com/had-catch-all"
 )
 
 // ReconcileObject handles the reconciliation logic for CustomHTTPRoute resources.
@@ -97,9 +100,11 @@ func (r *CustomHTTPRouteReconciler) ReconcileObject(
 		}
 	}
 
-	// Update the last-target annotation — must succeed to ensure future target changes are tracked
-	if err := r.ensureLastTargetAnnotation(ctx, resourceManifest, target); err != nil {
-		return fmt.Errorf("failed to update last-target annotation: %w", err)
+	// Update the last-target annotation — skip for deletions as the resource is being removed
+	if eventType != watch.Deleted {
+		if err := r.ensureLastTargetAnnotation(ctx, resourceManifest, target); err != nil {
+			return fmt.Errorf("failed to update last-target annotation: %w", err)
+		}
 	}
 
 	// Rebuild ConfigMaps for the current target
@@ -107,10 +112,24 @@ func (r *CustomHTTPRouteReconciler) ReconcileObject(
 		return err
 	}
 
-	// Reconcile catch-all EnvoyFilter only if this route has a catchAllRoute configured
-	if resourceManifest.Spec.CatchAllRoute != nil || eventType == watch.Deleted {
+	// Reconcile catch-all EnvoyFilter when:
+	// - the route currently has catchAllRoute configured
+	// - the route is being deleted (may have had catch-all entries)
+	// - the route previously had catchAllRoute but it was removed (annotation present, field nil)
+	hadCatchAll := resourceManifest.Annotations[hadCatchAllAnnotation] == "true"
+	hasCatchAll := resourceManifest.Spec.CatchAllRoute != nil
+	needsCatchAllReconcile := hasCatchAll || eventType == watch.Deleted || hadCatchAll
+
+	if needsCatchAllReconcile {
 		if err := r.reconcileCatchAllFromAllRoutes(ctx); err != nil {
 			return fmt.Errorf("failed to reconcile catch-all routes: %w", err)
+		}
+	}
+
+	// Track whether this route has catchAllRoute for future change detection — skip for deletions
+	if eventType != watch.Deleted {
+		if err := r.ensureHadCatchAllAnnotation(ctx, resourceManifest, hasCatchAll); err != nil {
+			return fmt.Errorf("failed to update had-catch-all annotation: %w", err)
 		}
 	}
 
@@ -130,6 +149,31 @@ func (r *CustomHTTPRouteReconciler) ensureLastTargetAnnotation(
 		resource.Annotations = make(map[string]string)
 	}
 	resource.Annotations[lastTargetAnnotation] = target
+	return r.Update(ctx, resource)
+}
+
+// ensureHadCatchAllAnnotation sets or removes the had-catch-all annotation to track catchAllRoute presence.
+func (r *CustomHTTPRouteReconciler) ensureHadCatchAllAnnotation(
+	ctx context.Context,
+	resource *v1alpha1.CustomHTTPRoute,
+	hasCatchAll bool,
+) error {
+	currentValue := resource.Annotations[hadCatchAllAnnotation]
+	desiredValue := ""
+	if hasCatchAll {
+		desiredValue = "true"
+	}
+	if currentValue == desiredValue {
+		return nil
+	}
+	if resource.Annotations == nil {
+		resource.Annotations = make(map[string]string)
+	}
+	if hasCatchAll {
+		resource.Annotations[hadCatchAllAnnotation] = "true"
+	} else {
+		delete(resource.Annotations, hadCatchAllAnnotation)
+	}
 	return r.Update(ctx, resource)
 }
 

--- a/internal/controller/customhttproute/sync_test.go
+++ b/internal/controller/customhttproute/sync_test.go
@@ -1,0 +1,400 @@
+/*
+Copyright 2024-2026 Freepik Company S.L.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package customhttproute
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/freepik-company/customrouter/api/v1alpha1"
+	"github.com/freepik-company/customrouter/pkg/routes"
+)
+
+func newScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = v1alpha1.AddToScheme(s)
+	_ = corev1.AddToScheme(s)
+	return s
+}
+
+func newReconciler(objs ...runtime.Object) *CustomHTTPRouteReconciler {
+	scheme := newScheme()
+	clientObjs := make([]runtime.Object, len(objs))
+	copy(clientObjs, objs)
+	cb := fake.NewClientBuilder().WithScheme(scheme)
+	for _, obj := range clientObjs {
+		cb = cb.WithRuntimeObjects(obj)
+	}
+	cb = cb.WithIndex(&v1alpha1.CustomHTTPRoute{}, targetRefIndexField, func(obj client.Object) []string {
+		route := obj.(*v1alpha1.CustomHTTPRoute)
+		return []string{route.Spec.TargetRef.Name}
+	})
+	return &CustomHTTPRouteReconciler{
+		Client:             cb.Build(),
+		Scheme:             scheme,
+		ConfigMapNamespace: "test-ns",
+	}
+}
+
+func TestMapsEqual(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b map[string]string
+		want bool
+	}{
+		{"both nil", nil, nil, true},
+		{"both empty", map[string]string{}, map[string]string{}, true},
+		{"equal", map[string]string{"a": "1", "b": "2"}, map[string]string{"a": "1", "b": "2"}, true},
+		{"different values", map[string]string{"a": "1"}, map[string]string{"a": "2"}, false},
+		{"different keys", map[string]string{"a": "1"}, map[string]string{"b": "1"}, false},
+		{"different lengths", map[string]string{"a": "1"}, map[string]string{"a": "1", "b": "2"}, false},
+		{"nil vs empty", nil, map[string]string{}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mapsEqual(tt.a, tt.b); got != tt.want {
+				t.Errorf("mapsEqual() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPartitionConfig_SinglePartition(t *testing.T) {
+	r := &CustomHTTPRouteReconciler{ConfigMapNamespace: "ns"}
+	config := &routes.RoutesConfig{
+		Version: 1,
+		Hosts: map[string][]routes.Route{
+			"example.com": {{Path: "/api", Type: "prefix", Backend: "svc.ns.svc.cluster.local:80"}},
+		},
+	}
+
+	partitions := r.partitionConfig("default", config)
+	if len(partitions) != 1 {
+		t.Fatalf("expected 1 partition, got %d", len(partitions))
+	}
+	if partitions[0].Name != "customrouter-routes-default-0" {
+		t.Errorf("expected name customrouter-routes-default-0, got %s", partitions[0].Name)
+	}
+	if partitions[0].Target != "default" {
+		t.Errorf("expected target default, got %s", partitions[0].Target)
+	}
+}
+
+func TestRebuildConfigMapsForTarget_OnlyAffectsOwnTarget(t *testing.T) {
+	route1 := &v1alpha1.CustomHTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "route-a", Namespace: "ns", UID: "uid-a"},
+		Spec: v1alpha1.CustomHTTPRouteSpec{
+			Hostnames: []string{"a.example.com"},
+			TargetRef: v1alpha1.TargetRef{Name: "target-a"},
+			Rules: []v1alpha1.Rule{
+				{
+					BackendRefs: []v1alpha1.BackendRef{{Name: "svc", Namespace: "ns", Port: 80}},
+					Matches:     []v1alpha1.PathMatch{{Path: "/a", Type: "Exact"}},
+				},
+			},
+		},
+	}
+	route2 := &v1alpha1.CustomHTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "route-b", Namespace: "ns", UID: "uid-b"},
+		Spec: v1alpha1.CustomHTTPRouteSpec{
+			Hostnames: []string{"b.example.com"},
+			TargetRef: v1alpha1.TargetRef{Name: "target-b"},
+			Rules: []v1alpha1.Rule{
+				{
+					BackendRefs: []v1alpha1.BackendRef{{Name: "svc", Namespace: "ns", Port: 80}},
+					Matches:     []v1alpha1.PathMatch{{Path: "/b", Type: "Exact"}},
+				},
+			},
+		},
+	}
+
+	r := newReconciler(route1, route2)
+
+	// Rebuild only target-a
+	if err := r.rebuildConfigMapsForTarget(context.Background(), "target-a"); err != nil {
+		t.Fatalf("rebuildConfigMapsForTarget failed: %v", err)
+	}
+
+	// Verify target-a ConfigMap exists
+	cmA := &corev1.ConfigMap{}
+	err := r.Get(context.Background(), types.NamespacedName{
+		Name: "customrouter-routes-target-a-0", Namespace: "test-ns",
+	}, cmA)
+	if err != nil {
+		t.Fatalf("expected ConfigMap for target-a, got error: %v", err)
+	}
+	if cmA.Labels[configMapTargetLabel] != "target-a" {
+		t.Errorf("expected target label target-a, got %s", cmA.Labels[configMapTargetLabel])
+	}
+
+	// Verify target-b ConfigMap does NOT exist
+	cmB := &corev1.ConfigMap{}
+	err = r.Get(context.Background(), types.NamespacedName{
+		Name: "customrouter-routes-target-b-0", Namespace: "test-ns",
+	}, cmB)
+	if err == nil {
+		t.Error("expected no ConfigMap for target-b, but one was found")
+	}
+}
+
+func TestRebuildConfigMapsForTarget_CleansStalePartitions(t *testing.T) {
+	// Pre-create a stale ConfigMap for target-a partition 1
+	staleCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "customrouter-routes-target-a-1",
+			Namespace: "test-ns",
+			Labels: map[string]string{
+				configMapManagedByLabel: configMapManagedByValue,
+				configMapTargetLabel:   "target-a",
+				configMapPartLabel:     "1",
+			},
+		},
+		Data: map[string]string{routesDataKey: `{"version":1,"hosts":{}}`},
+	}
+
+	route := &v1alpha1.CustomHTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "route-a", Namespace: "ns", UID: "uid-a"},
+		Spec: v1alpha1.CustomHTTPRouteSpec{
+			Hostnames: []string{"a.example.com"},
+			TargetRef: v1alpha1.TargetRef{Name: "target-a"},
+			Rules: []v1alpha1.Rule{
+				{
+					BackendRefs: []v1alpha1.BackendRef{{Name: "svc", Namespace: "ns", Port: 80}},
+					Matches:     []v1alpha1.PathMatch{{Path: "/a", Type: "Exact"}},
+				},
+			},
+		},
+	}
+
+	r := newReconciler(route, staleCM)
+
+	if err := r.rebuildConfigMapsForTarget(context.Background(), "target-a"); err != nil {
+		t.Fatalf("rebuildConfigMapsForTarget failed: %v", err)
+	}
+
+	// Partition 0 should exist
+	cm0 := &corev1.ConfigMap{}
+	if err := r.Get(context.Background(), types.NamespacedName{
+		Name: "customrouter-routes-target-a-0", Namespace: "test-ns",
+	}, cm0); err != nil {
+		t.Fatalf("expected partition 0 to exist: %v", err)
+	}
+
+	// Stale partition 1 should be deleted
+	cm1 := &corev1.ConfigMap{}
+	err := r.Get(context.Background(), types.NamespacedName{
+		Name: "customrouter-routes-target-a-1", Namespace: "test-ns",
+	}, cm1)
+	if err == nil {
+		t.Error("expected stale partition 1 to be deleted, but it still exists")
+	}
+}
+
+func TestRebuildConfigMapsForTarget_DeletesAllCMsWhenNoRoutes(t *testing.T) {
+	// ConfigMap exists but no routes for target-a
+	existingCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "customrouter-routes-target-a-0",
+			Namespace: "test-ns",
+			Labels: map[string]string{
+				configMapManagedByLabel: configMapManagedByValue,
+				configMapTargetLabel:   "target-a",
+				configMapPartLabel:     "0",
+			},
+		},
+		Data: map[string]string{routesDataKey: `{"version":1,"hosts":{"a.com":[]}}`},
+	}
+
+	r := newReconciler(existingCM)
+
+	if err := r.rebuildConfigMapsForTarget(context.Background(), "target-a"); err != nil {
+		t.Fatalf("rebuildConfigMapsForTarget failed: %v", err)
+	}
+
+	cm := &corev1.ConfigMap{}
+	err := r.Get(context.Background(), types.NamespacedName{
+		Name: "customrouter-routes-target-a-0", Namespace: "test-ns",
+	}, cm)
+	if err == nil {
+		t.Error("expected ConfigMap to be deleted when no routes exist for target")
+	}
+}
+
+func TestUpsertSingleConfigMap_SkipsUnchanged(t *testing.T) {
+	data := `{"version":1,"hosts":{"a.com":[{"path":"/api","type":"prefix","backend":"svc.ns.svc.cluster.local:80"}]}}`
+	labels := map[string]string{
+		"app.kubernetes.io/name": "customrouter",
+		configMapManagedByLabel:  configMapManagedByValue,
+		configMapTargetLabel:     "target-a",
+		configMapPartLabel:       "0",
+	}
+
+	existingCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "customrouter-routes-target-a-0",
+			Namespace: "test-ns",
+			Labels:    labels,
+		},
+		Data: map[string]string{routesDataKey: data},
+	}
+
+	r := newReconciler(existingCM)
+
+	partition := ConfigMapPartition{
+		Name:   "customrouter-routes-target-a-0",
+		Target: "target-a",
+		Data:   data,
+	}
+
+	// Should succeed without error (skip update)
+	if err := r.upsertSingleConfigMap(context.Background(), partition); err != nil {
+		t.Fatalf("upsertSingleConfigMap failed: %v", err)
+	}
+
+	// Verify the ConfigMap still has the same ResourceVersion (not updated)
+	cm := &corev1.ConfigMap{}
+	if err := r.Get(context.Background(), types.NamespacedName{
+		Name: "customrouter-routes-target-a-0", Namespace: "test-ns",
+	}, cm); err != nil {
+		t.Fatalf("failed to get ConfigMap: %v", err)
+	}
+	if cm.ResourceVersion != existingCM.ResourceVersion {
+		t.Error("ConfigMap was updated despite having the same content")
+	}
+}
+
+func TestUpsertSingleConfigMap_CreatesNew(t *testing.T) {
+	r := newReconciler()
+
+	partition := ConfigMapPartition{
+		Name:   "customrouter-routes-target-a-0",
+		Target: "target-a",
+		Data:   `{"version":1,"hosts":{}}`,
+	}
+
+	if err := r.upsertSingleConfigMap(context.Background(), partition); err != nil {
+		t.Fatalf("upsertSingleConfigMap failed: %v", err)
+	}
+
+	cm := &corev1.ConfigMap{}
+	if err := r.Get(context.Background(), types.NamespacedName{
+		Name: "customrouter-routes-target-a-0", Namespace: "test-ns",
+	}, cm); err != nil {
+		t.Fatalf("expected ConfigMap to be created: %v", err)
+	}
+	if cm.Data[routesDataKey] != partition.Data {
+		t.Errorf("unexpected data: %s", cm.Data[routesDataKey])
+	}
+}
+
+func TestResolveExternalNames(t *testing.T) {
+	extSvc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "ext-svc", Namespace: "ns"},
+		Spec: corev1.ServiceSpec{
+			Type:         corev1.ServiceTypeExternalName,
+			ExternalName: "external.example.com",
+		},
+	}
+	normalSvc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "normal-svc", Namespace: "ns"},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeClusterIP,
+		},
+	}
+
+	r := newReconciler(extSvc, normalSvc)
+
+	routes := []*v1alpha1.CustomHTTPRoute{
+		{
+			Spec: v1alpha1.CustomHTTPRouteSpec{
+				Rules: []v1alpha1.Rule{
+					{BackendRefs: []v1alpha1.BackendRef{
+						{Name: "ext-svc", Namespace: "ns", Port: 80},
+						{Name: "normal-svc", Namespace: "ns", Port: 80},
+						{Name: "missing-svc", Namespace: "ns", Port: 80},
+					}},
+				},
+			},
+		},
+	}
+
+	result := r.resolveExternalNames(context.Background(), routes)
+
+	if result["ext-svc/ns"] != "external.example.com" {
+		t.Errorf("expected ExternalName to be resolved, got %q", result["ext-svc/ns"])
+	}
+	if _, ok := result["normal-svc/ns"]; ok {
+		t.Error("normal ClusterIP service should not appear in externalNames map")
+	}
+	if _, ok := result["missing-svc/ns"]; ok {
+		t.Error("missing service should not appear in externalNames map")
+	}
+}
+
+func TestDeleteStaleConfigMapsForTarget_OnlyDeletesOwnTarget(t *testing.T) {
+	cmA := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "customrouter-routes-target-a-0",
+			Namespace: "test-ns",
+			Labels: map[string]string{
+				configMapManagedByLabel: configMapManagedByValue,
+				configMapTargetLabel:   "target-a",
+			},
+		},
+	}
+	cmB := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "customrouter-routes-target-b-0",
+			Namespace: "test-ns",
+			Labels: map[string]string{
+				configMapManagedByLabel: configMapManagedByValue,
+				configMapTargetLabel:   "target-b",
+			},
+		},
+	}
+
+	r := newReconciler(cmA, cmB)
+
+	// Delete stale for target-a with empty active set (should delete cmA)
+	if err := r.deleteStaleConfigMapsForTarget(context.Background(), "target-a", map[string]bool{}); err != nil {
+		t.Fatalf("deleteStaleConfigMapsForTarget failed: %v", err)
+	}
+
+	// target-a's CM should be gone
+	cm := &corev1.ConfigMap{}
+	err := r.Get(context.Background(), types.NamespacedName{
+		Name: "customrouter-routes-target-a-0", Namespace: "test-ns",
+	}, cm)
+	if err == nil {
+		t.Error("expected target-a ConfigMap to be deleted")
+	}
+
+	// target-b's CM should still exist
+	err = r.Get(context.Background(), types.NamespacedName{
+		Name: "customrouter-routes-target-b-0", Namespace: "test-ns",
+	}, cm)
+	if err != nil {
+		t.Errorf("target-b ConfigMap should still exist: %v", err)
+	}
+}

--- a/internal/controller/customhttproute/sync_test.go
+++ b/internal/controller/customhttproute/sync_test.go
@@ -166,8 +166,8 @@ func TestRebuildConfigMapsForTarget_CleansStalePartitions(t *testing.T) {
 			Namespace: "test-ns",
 			Labels: map[string]string{
 				configMapManagedByLabel: configMapManagedByValue,
-				configMapTargetLabel:   "target-a",
-				configMapPartLabel:     "1",
+				configMapTargetLabel:    "target-a",
+				configMapPartLabel:      "1",
 			},
 		},
 		Data: map[string]string{routesDataKey: `{"version":1,"hosts":{}}`},
@@ -219,8 +219,8 @@ func TestRebuildConfigMapsForTarget_DeletesAllCMsWhenNoRoutes(t *testing.T) {
 			Namespace: "test-ns",
 			Labels: map[string]string{
 				configMapManagedByLabel: configMapManagedByValue,
-				configMapTargetLabel:   "target-a",
-				configMapPartLabel:     "0",
+				configMapTargetLabel:    "target-a",
+				configMapPartLabel:      "0",
 			},
 		},
 		Data: map[string]string{routesDataKey: `{"version":1,"hosts":{"a.com":[]}}`},
@@ -325,7 +325,7 @@ func TestResolveExternalNames(t *testing.T) {
 
 	r := newReconciler(extSvc, normalSvc)
 
-	routes := []*v1alpha1.CustomHTTPRoute{
+	testRoutes := []*v1alpha1.CustomHTTPRoute{
 		{
 			Spec: v1alpha1.CustomHTTPRouteSpec{
 				Rules: []v1alpha1.Rule{
@@ -339,7 +339,7 @@ func TestResolveExternalNames(t *testing.T) {
 		},
 	}
 
-	result := r.resolveExternalNames(context.Background(), routes)
+	result := r.resolveExternalNames(context.Background(), testRoutes)
 
 	if result["ext-svc/ns"] != "external.example.com" {
 		t.Errorf("expected ExternalName to be resolved, got %q", result["ext-svc/ns"])
@@ -359,7 +359,7 @@ func TestDeleteStaleConfigMapsForTarget_OnlyDeletesOwnTarget(t *testing.T) {
 			Namespace: "test-ns",
 			Labels: map[string]string{
 				configMapManagedByLabel: configMapManagedByValue,
-				configMapTargetLabel:   "target-a",
+				configMapTargetLabel:    "target-a",
 			},
 		},
 	}
@@ -369,7 +369,7 @@ func TestDeleteStaleConfigMapsForTarget_OnlyDeletesOwnTarget(t *testing.T) {
 			Namespace: "test-ns",
 			Labels: map[string]string{
 				configMapManagedByLabel: configMapManagedByValue,
-				configMapTargetLabel:   "target-b",
+				configMapTargetLabel:    "target-b",
 			},
 		},
 	}

--- a/pkg/routes/expand_test.go
+++ b/pkg/routes/expand_test.go
@@ -1174,30 +1174,33 @@ func TestExpandRoutesWithInlinePrefixPlaceholder(t *testing.T) {
 		t.Fatalf("expected 2 routes, got %d: %+v", len(routes), routes)
 	}
 
-	var inlineRoute, normalRoute *Route
+	var inlineIdx, normalIdx int
+	var foundInline, foundNormal bool
 	for i := range routes {
 		if strings.Contains(routes[i].Path, "_app") {
-			inlineRoute = &routes[i]
+			inlineIdx = i
+			foundInline = true
 		} else {
-			normalRoute = &routes[i]
+			normalIdx = i
+			foundNormal = true
 		}
 	}
 
-	if inlineRoute == nil {
+	if !foundInline {
 		t.Fatal("inline prefix route not found")
 	}
-	if normalRoute == nil {
+	if !foundNormal {
 		t.Fatal("normal route not found")
 	}
 
 	expectedInline := "^/_app/data/[^/]+/(es|fr|de)/"
-	if inlineRoute.Path != expectedInline {
-		t.Errorf("inline route:\nexpected: %s\ngot:      %s", expectedInline, inlineRoute.Path)
+	if routes[inlineIdx].Path != expectedInline {
+		t.Errorf("inline route:\nexpected: %s\ngot:      %s", expectedInline, routes[inlineIdx].Path)
 	}
 
 	expectedNormal := "^/(es|fr|de)/users/[0-9]+$"
-	if normalRoute.Path != expectedNormal {
-		t.Errorf("normal route:\nexpected: %s\ngot:      %s", expectedNormal, normalRoute.Path)
+	if routes[normalIdx].Path != expectedNormal {
+		t.Errorf("normal route:\nexpected: %s\ngot:      %s", expectedNormal, routes[normalIdx].Path)
 	}
 }
 
@@ -1275,13 +1278,14 @@ func TestConvertActionsPassesReplacePrefixMatch(t *testing.T) {
 				if got != nil {
 					t.Errorf("expected nil, got %v", *got)
 				}
-			} else {
-				if got == nil {
-					t.Fatalf("expected non-nil, got nil")
-				}
-				if *got != tt.wantVal {
-					t.Errorf("expected %v, got %v", tt.wantVal, *got)
-				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected non-nil, got nil")
+				return
+			}
+			if *got != tt.wantVal {
+				t.Errorf("expected %v, got %v", tt.wantVal, *got)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- **Rebuild per target**: each reconciliation now only processes routes for the affected target instead of listing all routes and rebuilding all ConfigMaps globally. Reduces work from O(N) to O(N/T) per reconcile, eliminating the O(N²) pattern that caused OOMKilled when deploying many routes at once.
- **Field indexer on `spec.targetRef.name`**: uses the informer cache index for O(1) per-target listing instead of listing all routes and filtering in Go.
- **Skip unchanged upserts**: compares ConfigMap data and labels before issuing an Update, avoiding unnecessary API writes and conflict retries.
- **Per-target stale cleanup**: `deleteStaleConfigMapsForTarget` only lists/deletes ConfigMaps for the affected target, not all managed ConfigMaps.
- **`--max-concurrent-reconciles` flag** (default: 5): allows parallel processing of different targets during burst deployments.
- **Target change tracking**: `customrouter.freepik.com/last-target` annotation ensures old target's ConfigMaps are cleaned up when `targetRef` changes.
- **ExternalName dedup**: extracted `resolveExternalNames` helper that marks non-ExternalName services as seen to avoid redundant lookups.

### Context

When deploying many CustomHTTPRoutes simultaneously (e.g., migrating from Istio), the operator was getting OOMKilled because every single route change triggered a full rebuild of ALL ConfigMaps for ALL targets. With 500 routes across 10 targets, each reconcile processed all 500 routes — and with 500 concurrent reconciles queued, this produced ~250,000 list+expand+merge operations.

### Impact

| Metric | Before | After |
|--------|--------|-------|
| Routes processed per reconcile | ALL | Only the target's routes |
| ConfigMaps written per reconcile | All targets | 1 target (or 0 if unchanged) |
| Concurrent reconciliations | 1 | 5 (configurable) |
| Memory during burst of N routes, T targets | O(N × T) repeated | O(N/T) per reconcile |

### No impact on extproc

ConfigMap labels, `routes.json` key, JSON format, and watch label selectors are unchanged. The extproc side requires zero changes.

## Test plan

- [x] `go build ./...` passes
- [x] All existing unit tests pass (`go test ./...`)
- [ ] Deploy 200+ routes simultaneously in kind cluster, verify no OOM with 256Mi limit
- [ ] Verify in logs that each reconcile only processes 1 target
- [ ] Verify ConfigMap cleanup when changing a route's targetRef

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors core reconciliation to rebuild/update ConfigMaps per `targetRef` (with concurrent reconciles and new annotations), which could affect cleanup behavior and catch-all EnvoyFilter reconciliation under load. CRD validation limits are also expanded, increasing potential per-object size/scale considerations.
> 
> **Overview**
> Improves `CustomHTTPRoute` reconciliation performance by **rebuilding route ConfigMaps per `spec.targetRef.name`** (using a new field indexer) instead of reprocessing all routes/targets on every event, and cleans up stale partitions **only for the affected target**.
> 
> Adds controller tuning and correctness safeguards: a new `--max-concurrent-reconciles` flag wired into controller options, annotations to track `last-target` (to clean up old target ConfigMaps on target changes) and `had-catch-all` (to trigger catch-all EnvoyFilter reconciliation only when needed), plus upsert optimizations to skip unchanged ConfigMap updates and broaden retry handling for conflicts/already-exists.
> 
> Also bumps CRD validation limits for `hostnames` and rule `matches` from 50 to 128 (regenerating CRDs), updates Helm chart version to `0.5.2`, upgrades `golangci-lint`, and adds focused unit tests for the new per-target rebuild/cleanup behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38ba89c0da0135c3adc3dbfdd389cda52d4f04de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->