### PR TITLE
feat(extproc): add Prometheus metrics and ServiceMonitor

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: customrouter
 description: A Helm chart for CustomRouter - Kubernetes operator and external processor for dynamic HTTP routing
 type: application
-version: 0.5.2
-appVersion: "0.5.2"
+version: 0.5.3
+appVersion: "0.5.3"
 kubeVersion: ">= 1.26.0-0"
 keywords:
   - kubernetes

--- a/chart/templates/extproc-deployment.yaml
+++ b/chart/templates/extproc-deployment.yaml
@@ -45,6 +45,11 @@ spec:
             - name: grpc
               containerPort: {{ $config.service.port }}
               protocol: TCP
+            {{- if and $config.metrics $config.metrics.enabled }}
+            - name: metrics
+              containerPort: {{ $config.metrics.port | default 9090 }}
+              protocol: TCP
+            {{- end }}
           {{- with $config.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}

--- a/chart/templates/extproc-service.yaml
+++ b/chart/templates/extproc-service.yaml
@@ -15,6 +15,12 @@ spec:
       port: {{ $config.service.port }}
       targetPort: grpc
       protocol: TCP
+    {{- if and $config.metrics $config.metrics.enabled }}
+    - name: metrics
+      port: {{ $config.metrics.port | default 9090 }}
+      targetPort: metrics
+      protocol: TCP
+    {{- end }}
   selector:
     {{- include "customrouter.extproc.selectorLabels" (dict "name" $name "root" $) | nindent 4 }}
 {{- end }}

--- a/chart/templates/extproc-servicemonitor.yaml
+++ b/chart/templates/extproc-servicemonitor.yaml
@@ -1,0 +1,31 @@
+{{- range $name, $config := .Values.externalProcessors }}
+{{- if and $config.enabled $config.metrics $config.metrics.enabled $config.metrics.serviceMonitor $config.metrics.serviceMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "customrouter.extproc.name" (dict "name" $name "root" $) }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "customrouter.extproc.labels" (dict "name" $name "root" $) | nindent 4 }}
+    {{- with $config.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "customrouter.extproc.selectorLabels" (dict "name" $name "root" $) | nindent 6 }}
+  endpoints:
+    - port: metrics
+      interval: {{ $config.metrics.serviceMonitor.interval | default "30s" }}
+      path: /metrics
+      {{- with $config.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $config.metrics.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -218,11 +218,31 @@ externalProcessors:
       - --grpc-max-connection-idle=5m
       - --grpc-max-connection-age=30m
       - --grpc-max-connection-age-grace=10s
+      - --metrics-addr=:9090
 
     # -- Service configuration
     service:
       type: ClusterIP
       port: 9001
+
+    # -- Prometheus metrics configuration
+    metrics:
+      # -- Enable Prometheus metrics endpoint
+      enabled: true
+      # -- Port to expose metrics on
+      port: 9090
+      # -- Create a ServiceMonitor resource for Prometheus Operator
+      serviceMonitor:
+        # -- Enable ServiceMonitor creation
+        enabled: false
+        # -- Scrape interval
+        interval: 30s
+        # -- Additional labels for the ServiceMonitor
+        labels: {}
+        # -- Metric relabeling configs
+        metricRelabelings: []
+        # -- Relabeling configs
+        relabelings: []
 
     # -- Pod security context
     podSecurityContext:

--- a/cmd/extproc/main.go
+++ b/cmd/extproc/main.go
@@ -48,6 +48,8 @@ func main() {
 	flag.BoolVar(&config.AccessLogEnabled, "access-log", config.AccessLogEnabled, "Enable access logging")
 	flag.StringVar(&config.RoutesNamespace, "routes-configmap-namespace", config.RoutesNamespace,
 		"Namespace to read route ConfigMaps from (empty = all namespaces)")
+	flag.StringVar(&config.MetricsAddr, "metrics-addr", config.MetricsAddr,
+		"Address to expose Prometheus metrics on (empty to disable)")
 
 	// gRPC server configuration flags
 	flag.IntVar(&config.MaxRecvMsgSize, "grpc-max-recv-msg-size",

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.36.1
+	github.com/prometheus/client_golang v1.23.0
 	go.uber.org/zap v1.27.0
 	google.golang.org/grpc v1.78.0
 	k8s.io/api v0.34.1
@@ -54,7 +55,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.23.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.65.0 // indirect
 	github.com/prometheus/procfs v0.17.0 // indirect

--- a/internal/extproc/config.go
+++ b/internal/extproc/config.go
@@ -69,6 +69,10 @@ type ServerConfig struct {
 	// RoutesNamespace restricts ConfigMap loading to a specific namespace.
 	// Empty string means all namespaces (backward compatible).
 	RoutesNamespace string
+
+	// MetricsAddr is the address to expose Prometheus metrics on (e.g. ":9090").
+	// Empty string disables the metrics endpoint.
+	MetricsAddr string
 }
 
 // DefaultServerConfig returns a ServerConfig with production-ready defaults
@@ -85,5 +89,6 @@ func DefaultServerConfig() *ServerConfig {
 		MaxConnectionAge:      30 * time.Minute, // Force reconnect after 30m for load balancing
 		MaxConnectionAgeGrace: 10 * time.Second, // Grace period for in-flight requests
 		AccessLogEnabled:      true,
+		MetricsAddr:           ":9090",
 	}
 }

--- a/internal/extproc/metrics.go
+++ b/internal/extproc/metrics.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2024-2026 Freepik Company S.L.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extproc
+
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+const metricsNamespace = "customrouter"
+
+var (
+	requestsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "requests_total",
+			Help:      "Total number of requests processed by the external processor.",
+		},
+		[]string{"route_found"},
+	)
+
+	requestDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Name:      "request_duration_seconds",
+			Help:      "Histogram of request processing duration in seconds.",
+			Buckets:   []float64{0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1},
+		},
+		[]string{"route_found"},
+	)
+
+	routeMatchesTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "route_matches_total",
+			Help:      "Total number of route matches by match type.",
+		},
+		[]string{"match_type"},
+	)
+
+	routeNotFoundTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "route_not_found_total",
+			Help:      "Total number of requests where no matching route was found.",
+		},
+	)
+
+	processingErrorsTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "processing_errors_total",
+			Help:      "Total number of errors during request processing.",
+		},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(
+		requestsTotal,
+		requestDuration,
+		routeMatchesTotal,
+		routeNotFoundTotal,
+		processingErrorsTotal,
+	)
+}
+
+// MetricsHandler returns an HTTP handler for Prometheus metrics.
+func MetricsHandler() http.Handler {
+	return promhttp.Handler()
+}

--- a/internal/extproc/processor.go
+++ b/internal/extproc/processor.go
@@ -20,6 +20,7 @@ package extproc
 import (
 	"fmt"
 	"io"
+	"strconv"
 	"time"
 
 	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
@@ -97,6 +98,17 @@ func (p *Processor) Process(stream extprocv3.ExternalProcessor_ProcessServer) er
 
 func (p *Processor) logAccess(ctx *requestContext) {
 	ctx.processingTimeNs = time.Since(ctx.startTime).Nanoseconds()
+
+	// Record metrics
+	found := strconv.FormatBool(ctx.routeFound)
+	durationSec := float64(ctx.processingTimeNs) / 1e9
+	requestsTotal.WithLabelValues(found).Inc()
+	requestDuration.WithLabelValues(found).Observe(durationSec)
+	if ctx.routeFound {
+		routeMatchesTotal.WithLabelValues(ctx.matchedType).Inc()
+	} else {
+		routeNotFoundTotal.Inc()
+	}
 
 	if ctx.routeFound {
 		p.logger.Info("access",

--- a/internal/extproc/server.go
+++ b/internal/extproc/server.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/http"
 	"time"
 
 	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
@@ -135,12 +136,36 @@ func (s *Server) Start(ctx context.Context) error {
 		zap.Duration("max_connection_idle", s.config.MaxConnectionIdle),
 		zap.Duration("max_connection_age", s.config.MaxConnectionAge),
 		zap.Bool("access_log_enabled", s.config.AccessLogEnabled),
+		zap.String("metrics_addr", s.config.MetricsAddr),
 	)
+
+	// Start metrics HTTP server if configured
+	var metricsServer *http.Server
+	if s.config.MetricsAddr != "" {
+		mux := http.NewServeMux()
+		mux.Handle("/metrics", MetricsHandler())
+		metricsServer = &http.Server{
+			Addr:              s.config.MetricsAddr,
+			Handler:           mux,
+			ReadHeaderTimeout: 10 * time.Second,
+		}
+		go func() {
+			s.logger.Info("starting metrics server",
+				zap.String("addr", s.config.MetricsAddr),
+			)
+			if err := metricsServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				s.logger.Error("metrics server error", zap.Error(err))
+			}
+		}()
+	}
 
 	// Handle graceful shutdown
 	go func() {
 		<-ctx.Done()
 		s.logger.Info("shutting down extproc server")
+		if metricsServer != nil {
+			_ = metricsServer.Close()
+		}
 		s.grpcServer.GracefulStop()
 		if err := s.loader.Close(); err != nil {
 			s.logger.Warn("failed to close loader", zap.Error(err))


### PR DESCRIPTION
## Summary
- Adds native Prometheus metrics to the external processor (`customrouter_requests_total`, `customrouter_request_duration_seconds`, `customrouter_route_matches_total`, `customrouter_route_not_found_total`, `customrouter_processing_errors_total`)
- HTTP metrics endpoint on `--metrics-addr` (default `:9090`)
- ServiceMonitor Helm template for Prometheus Operator auto-discovery
- Metrics port exposed in Service and Deployment templates
- Bumps to `0.5.3`

## Context
Required for observability: monitoring routing success/failure rates, latency, and enabling alerting on routing errors.

## Test plan
- [x] All existing tests pass
- [x] Build succeeds
- [ ] Deploy to staging and verify `/metrics` endpoint returns Prometheus metrics

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new HTTP metrics server/port and wires request instrumentation into the extproc processing path, which can impact runtime behavior and resource usage. Metrics emission is also currently tied to `accessLogEnabled`, so disabling access logs would unintentionally disable metrics.
> 
> **Overview**
> Adds native Prometheus instrumentation to the external processor, including new counters/histograms and an HTTP `/metrics` endpoint controlled by a new `--metrics-addr` flag (default `:9090`). The extproc server now starts/shuts down this metrics HTTP server alongside the gRPC server.
> 
> Updates the Helm chart to expose an optional `metrics` port on the extproc `Deployment` and `Service`, introduces configurable `metrics` values (including optional Prometheus Operator `ServiceMonitor`), and bumps chart/app version to `0.5.3`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10d57df92f5c8dcfe3cfb07b8dd8ced3d4512f0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->