### PR TITLE
perf(ci): optimize release pipeline with native cross-compilation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,8 +78,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ matrix.image.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image.name }}
 
   create-release:
     needs: build-and-push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,16 +13,10 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  OPERATOR_IMAGE_NAME: ${{ github.repository }}/operator
-  EXTERNAL_PROCESSOR_IMAGE_NAME: ${{ github.repository }}/external-processor
 
 jobs:
-  build-and-push:
+  test:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -35,8 +29,23 @@ jobs:
       - name: Run tests
         run: make test
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+  build-and-push:
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        image:
+          - name: operator
+            file: ./build/Dockerfile.controller
+          - name: external-processor
+            file: ./build/Dockerfile.extproc
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -48,11 +57,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata for Operator
-        id: meta-operator
+      - name: Extract metadata
+        id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.OPERATOR_IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ github.repository }}/${{ matrix.image.name }}
           tags: |
             type=semver,pattern=v{{version}},enable=${{ github.event_name == 'push' }}
             type=semver,pattern=v{{major}}.{{minor}},enable=${{ github.event_name == 'push' }}
@@ -60,39 +69,15 @@ jobs:
             type=sha,enable=${{ github.event_name == 'push' }}
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
-      - name: Extract metadata for External Processor
-        id: meta-external-processor
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.EXTERNAL_PROCESSOR_IMAGE_NAME }}
-          tags: |
-            type=semver,pattern=v{{version}},enable=${{ github.event_name == 'push' }}
-            type=semver,pattern=v{{major}}.{{minor}},enable=${{ github.event_name == 'push' }}
-            type=semver,pattern=v{{major}},enable=${{ github.event_name == 'push' }}
-            type=sha,enable=${{ github.event_name == 'push' }}
-            type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
-
-      - name: Build and push Operator image
+      - name: Build and push image
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: ./build/Dockerfile.controller
+          file: ${{ matrix.image.file }}
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta-operator.outputs.tags }}
-          labels: ${{ steps.meta-operator.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Build and push External Processor image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./build/Dockerfile.extproc
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta-external-processor.outputs.tags }}
-          labels: ${{ steps.meta-external-processor.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/Makefile
+++ b/Makefile
@@ -158,13 +158,10 @@ docker-push-all: docker-push docker-push-extproc ## Push all docker images.
 PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
 .PHONY: docker-buildx
 docker-buildx: ## Build and push docker image for the manager for cross-platform support
-	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
-	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' build/Dockerfile.controller > Dockerfile.cross
 	- $(CONTAINER_TOOL) buildx create --name customrouter-builder
 	$(CONTAINER_TOOL) buildx use customrouter-builder
-	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
+	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f build/Dockerfile.controller .
 	- $(CONTAINER_TOOL) buildx rm customrouter-builder
-	rm Dockerfile.cross
 
 .PHONY: build-installer
 build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.

--- a/build/Dockerfile.controller
+++ b/build/Dockerfile.controller
@@ -1,28 +1,17 @@
 # Build the controller binary
-FROM golang:1.25 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
 WORKDIR /workspace
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
+COPY go.mod go.sum ./
 RUN go mod download
 
-# Copy the Go source (relies on .dockerignore to filter)
 COPY . .
 
-# Build
-# the GOARCH has no default value to allow the binary to be built according to the host where the command
-# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
-# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
-# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -o manager cmd/main.go
+# Native Go cross-compilation — no QEMU emulation needed
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -trimpath -ldflags="-s -w" -o manager cmd/main.go
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .

--- a/build/Dockerfile.extproc
+++ b/build/Dockerfile.extproc
@@ -1,30 +1,22 @@
 # Build the extproc binary
-FROM golang:1.25 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
 WORKDIR /workspace
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
+COPY go.mod go.sum ./
 RUN go mod download
 
-# Copy the Go source (relies on .dockerignore to filter)
 COPY . .
 
-# Build
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -o extproc cmd/extproc/main.go
+# Native Go cross-compilation — no QEMU emulation needed
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -trimpath -ldflags="-s -w" -o extproc cmd/extproc/main.go
 
-# Use distroless as minimal base image to package the extproc binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/extproc .
 USER 65532:65532
 
-# Default routes directory
 VOLUME ["/etc/customrouter/routes"]
 
 ENTRYPOINT ["/extproc"]


### PR DESCRIPTION
## Summary
- **Use native Go cross-compilation** instead of QEMU emulation for arm64 builds (`FROM --platform=$BUILDPLATFORM`)
- **Parallelize** operator and extproc image builds via matrix strategy
- **Separate test job** so builds start immediately after tests pass
- **Smaller binaries** with `-trimpath -ldflags="-s -w"` (~32% reduction: 78MB → 53MB)
- **Remove QEMU** setup step (no longer needed)

## Estimated impact
~45 min → ~5-8 min release pipeline

## Verified locally
- `go test ./...` — all pass
- Cross-compilation amd64 + arm64 for both binaries — success
- `docker buildx build --platform linux/amd64` — both images build and run
- `docker buildx build --platform linux/arm64` — both images build (native cross-compile, no QEMU)
- Binary size comparison: 78MB (before) vs 53MB (after) for controller amd64

## Test plan
- [x] Local Go cross-compile amd64 + arm64
- [x] Local docker buildx for both platforms
- [x] Container smoke test (`--help` flag)
- [ ] CI workflows pass on this PR
- [ ] Release workflow runs fast on next tag

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the release workflow’s build/push orchestration and Docker build behavior (cross-platform builds, caching, image naming), which can break releases if misconfigured.
> 
> **Overview**
> Speeds up releases by splitting the workflow into a `test` job and a dependent `build-and-push` job, then building/pushing the operator and external-processor images via a matrix with per-image caching.
> 
> Switches both Dockerfiles to native Go cross-compilation (`FROM --platform=$BUILDPLATFORM`) and trims binaries (`-trimpath -ldflags="-s -w"`), eliminating the need for QEMU emulation. The `Makefile` `docker-buildx` target is simplified to build directly from `build/Dockerfile.controller` (no generated cross Dockerfile).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06226eb352dc53617fbd6aea03cc7c038edae3a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->