### PR TITLE
fix(extproc): preserve original request path on rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,6 +550,8 @@ rules:
 
 For `PathPrefix` matches, the rewrite replaces only the matched prefix and **preserves the remaining path suffix and query parameters**. For `Exact` and `Regex` matches, the rewrite replaces the entire path.
 
+When a rewrite changes the path, the original request path is automatically preserved in the `x-envoy-original-path` header. This ensures that access logs and observability tools that rely on this standard header (e.g. `%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%`) correctly reflect the path originally requested by the client.
+
 ```yaml
 rules:
   # Prefix rewrite: /mockup-editor-api/unity?page=1 -> /api/v1/unity?page=1

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: customrouter
 description: A Helm chart for CustomRouter - Kubernetes operator and external processor for dynamic HTTP routing
 type: application
-version: 0.5.8
-appVersion: "0.5.8"
+version: 0.5.9
+appVersion: "0.5.9"
 kubeVersion: ">= 1.26.0-0"
 keywords:
   - kubernetes

--- a/internal/extproc/router.go
+++ b/internal/extproc/router.go
@@ -377,6 +377,15 @@ func (p *Processor) buildForwardResponse(route *routes.Route, vars *requestVars,
 
 	// Add path rewrite if path was changed
 	if finalPath != vars.path {
+		// Preserve the original path so Istio/Envoy access logs can show it.
+		// The default log format reads %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%.
+		setHeaders = append(setHeaders, &corev3.HeaderValueOption{
+			Header: &corev3.HeaderValue{
+				Key:      "x-envoy-original-path",
+				RawValue: []byte(vars.path),
+			},
+			AppendAction: corev3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD,
+		})
 		setHeaders = append(setHeaders, &corev3.HeaderValueOption{
 			Header: &corev3.HeaderValue{
 				Key:      ":path",

--- a/internal/extproc/router_test.go
+++ b/internal/extproc/router_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/freepik-company/customrouter/pkg/routes"
+	"go.uber.org/zap"
 )
 
 func boolPtr(v bool) *bool { return &v }
@@ -206,6 +207,74 @@ func TestStripQueryString(t *testing.T) {
 			got := stripQueryString(tt.input)
 			if got != tt.want {
 				t.Errorf("stripQueryString(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildForwardResponse_OriginalPathHeader(t *testing.T) {
+	logger := zap.NewNop()
+	p := NewProcessor(nil, logger, false)
+
+	tests := []struct {
+		name             string
+		route            *routes.Route
+		varsPath         string
+		wantOriginalPath string // empty means header should NOT be present
+	}{
+		{
+			name: "rewrite sets x-envoy-original-path",
+			route: &routes.Route{
+				Path:    "/old",
+				Type:    routes.RouteTypePrefix,
+				Backend: "backend.ns.svc.cluster.local:80",
+				Actions: []routes.RouteAction{
+					{Type: routes.ActionTypeRewrite, RewritePath: "/new"},
+				},
+			},
+			varsPath:         "/old/sub?q=1",
+			wantOriginalPath: "/old/sub?q=1",
+		},
+		{
+			name: "no rewrite omits x-envoy-original-path",
+			route: &routes.Route{
+				Path:    "/keep",
+				Type:    routes.RouteTypePrefix,
+				Backend: "backend.ns.svc.cluster.local:80",
+			},
+			varsPath:         "/keep/foo",
+			wantOriginalPath: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vars := &requestVars{
+				path:         tt.varsPath,
+				host:         "example.com",
+				pathSegments: splitPath(tt.varsPath),
+			}
+			reqCtx := &requestContext{authority: "example.com"}
+
+			resp, _, err := p.buildForwardResponse(tt.route, vars, reqCtx)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			headers := resp.GetRequestHeaders().GetResponse().GetHeaderMutation().GetSetHeaders()
+			var got string
+			for _, h := range headers {
+				if h.GetHeader().GetKey() == "x-envoy-original-path" {
+					got = string(h.GetHeader().GetRawValue())
+					break
+				}
+			}
+
+			if tt.wantOriginalPath == "" && got != "" {
+				t.Errorf("expected no x-envoy-original-path header, got %q", got)
+			}
+			if tt.wantOriginalPath != "" && got != tt.wantOriginalPath {
+				t.Errorf("x-envoy-original-path = %q, want %q", got, tt.wantOriginalPath)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Add `x-envoy-original-path` header with the client's original path before overwriting `:path` during rewrite actions
- Ensures access logs using `%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%` show the original request path instead of the rewritten one
- Bump chart version to 0.5.9

## Test plan

- [x] Unit test `TestBuildForwardResponse_OriginalPathHeader` validates the header is set on rewrite and absent otherwise
- [x] Full test suite passes (`go test ./...`)
- [x] Lint clean (`make lint` — 0 issues)
- [x] Deploy to staging and verify access logs show the original path for rewritten requests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single header mutation only when `:path` is rewritten, plus a unit test and doc/chart version bumps.
> 
> **Overview**
> **Preserves original request paths during rewrites for better observability.** When `buildForwardResponse` rewrites `:path`, it now also sets `x-envoy-original-path` to the pre-rewrite path so access logs using `%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%` show what the client requested.
> 
> Adds a unit test to assert the header is present only on rewrites, documents the behavior in `README.md`, and bumps the Helm chart `version`/`appVersion` to `0.5.9`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7f615cfaf95385c71002b0ee79933c8717b765b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->