### PR TITLE
feat(status): add CatchAllProgrammed condition to CustomHTTPRoute

### DIFF
--- a/api/v1alpha1/customhttproute_types.go
+++ b/api/v1alpha1/customhttproute_types.go
@@ -408,6 +408,7 @@ type CustomHTTPRouteStatus struct {
 // +kubebuilder:printcolumn:name="Target",type="string",JSONPath=".spec.targetRef.name",description="Target external processor"
 // +kubebuilder:printcolumn:name="Reconciled",type="string",JSONPath=".status.conditions[?(@.type=='Reconciled')].status",description="Whether the manifest was reconciled"
 // +kubebuilder:printcolumn:name="ConfigMapSynced",type="string",JSONPath=".status.conditions[?(@.type=='ConfigMapSynced')].status",description="Whether the ConfigMap was synced"
+// +kubebuilder:printcolumn:name="CatchAll",type="string",JSONPath=".status.conditions[?(@.type=='CatchAllProgrammed')].reason",description="Whether the route's catchAllRoute is applied to the dataplane"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // CustomHTTPRoute is the Schema for the customhttproutes API

--- a/api/v1alpha1/customhttproute_types.go
+++ b/api/v1alpha1/customhttproute_types.go
@@ -83,6 +83,9 @@ const (
 
 	// ConditionTypeConfigMapSynced indicates whether the ConfigMap was successfully generated
 	ConditionTypeConfigMapSynced = "ConfigMapSynced"
+
+	// ConditionTypeCatchAllProgrammed indicates whether the route's catchAllRoute is applied to the dataplane
+	ConditionTypeCatchAllProgrammed = "CatchAllProgrammed"
 )
 
 // PathPrefixes defines path prefixes configuration (e.g., for languages)

--- a/chart/crds/customrouter.freepik.com_customhttproutes.yaml
+++ b/chart/crds/customrouter.freepik.com_customhttproutes.yaml
@@ -27,6 +27,10 @@ spec:
       jsonPath: .status.conditions[?(@.type=='ConfigMapSynced')].status
       name: ConfigMapSynced
       type: string
+    - description: Whether the route's catchAllRoute is applied to the dataplane
+      jsonPath: .status.conditions[?(@.type=='CatchAllProgrammed')].reason
+      name: CatchAll
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/config/operator/deploy/crd/bases/customrouter.freepik.com_customhttproutes.yaml
+++ b/config/operator/deploy/crd/bases/customrouter.freepik.com_customhttproutes.yaml
@@ -27,6 +27,10 @@ spec:
       jsonPath: .status.conditions[?(@.type=='ConfigMapSynced')].status
       name: ConfigMapSynced
       type: string
+    - description: Whether the route's catchAllRoute is applied to the dataplane
+      jsonPath: .status.conditions[?(@.type=='CatchAllProgrammed')].reason
+      name: CatchAll
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/internal/controller/conditions.go
+++ b/internal/controller/conditions.go
@@ -33,4 +33,24 @@ const (
 	// ConditionReasonConfigMapError indicates an error syncing the ConfigMap
 	ConditionReasonConfigMapError        = "ConfigMapSyncError"
 	ConditionReasonConfigMapErrorMessage = "Failed to generate or sync ConfigMap"
+
+	// ConditionReasonCatchAllProgrammed indicates the catchAllRoute is applied on at least one EPA
+	ConditionReasonCatchAllProgrammed        = "Programmed"
+	ConditionReasonCatchAllProgrammedMessage = "catchAllRoute is applied to the dataplane"
+
+	// ConditionReasonCatchAllNotConfigured indicates the route has no catchAllRoute in its spec
+	ConditionReasonCatchAllNotConfigured        = "NotConfigured"
+	ConditionReasonCatchAllNotConfiguredMessage = "Route has no catchAllRoute configured"
+
+	// ConditionReasonCatchAllNoEPA indicates catchAllRoute is configured but no EPA exists to apply it
+	ConditionReasonCatchAllNoEPA        = "NoExternalProcessor"
+	ConditionReasonCatchAllNoEPAMessage = "catchAllRoute is configured but no ExternalProcessorAttachment exists"
+
+	// ConditionReasonCatchAllOverriddenByEPA indicates an EPA's own catchAllRoute overrides this route's
+	ConditionReasonCatchAllOverriddenByEPA        = "OverriddenByEPA"
+	ConditionReasonCatchAllOverriddenByEPAMessage = "catchAllRoute is overridden by an ExternalProcessorAttachment catchAllRoute for the same hostname"
+
+	// ConditionReasonCatchAllOverriddenByRoute indicates another CustomHTTPRoute wins the dedup for all hostnames
+	ConditionReasonCatchAllOverriddenByRoute        = "OverriddenByRoute"
+	ConditionReasonCatchAllOverriddenByRouteMessage = "catchAllRoute is overridden by another CustomHTTPRoute for the same hostname"
 )

--- a/internal/controller/customhttproute/catchall_test.go
+++ b/internal/controller/customhttproute/catchall_test.go
@@ -158,10 +158,11 @@ func TestCollectCatchAllEntries_SkipsDeleting(t *testing.T) {
 	}
 }
 
-func TestCollectCatchAllEntries_DuplicateHostnameLastWins(t *testing.T) {
+func TestCollectCatchAllEntries_DuplicateHostnameFirstNameWins(t *testing.T) {
 	routeList := &v1alpha1.CustomHTTPRouteList{
 		Items: []v1alpha1.CustomHTTPRoute{
 			{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "z-route"},
 				Spec: v1alpha1.CustomHTTPRouteSpec{
 					Hostnames: []string{"example.com"},
 					CatchAllRoute: &v1alpha1.CatchAllBackendRef{
@@ -173,6 +174,7 @@ func TestCollectCatchAllEntries_DuplicateHostnameLastWins(t *testing.T) {
 				},
 			},
 			{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "a-route"},
 				Spec: v1alpha1.CustomHTTPRouteSpec{
 					Hostnames: []string{"example.com"},
 					CatchAllRoute: &v1alpha1.CatchAllBackendRef{
@@ -190,7 +192,7 @@ func TestCollectCatchAllEntries_DuplicateHostnameLastWins(t *testing.T) {
 		t.Fatalf("expected 1 entry (deduplicated), got %d", len(entries))
 	}
 	if entries[0].BackendRef.Name != "svc-2" {
-		t.Errorf("expected last-wins for duplicate hostname, got %s", entries[0].BackendRef.Name)
+		t.Errorf("expected first-in-lex-order (a-route → svc-2) to win, got %s", entries[0].BackendRef.Name)
 	}
 }
 

--- a/internal/controller/customhttproute/controller.go
+++ b/internal/controller/customhttproute/controller.go
@@ -139,6 +139,13 @@ func (r *CustomHTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	r.UpdateConditionReconciled(objectManifest)
 	r.UpdateConditionConfigMapSynced(objectManifest)
 
+	catchAllStatus, catchAllErr := r.ComputeCatchAllProgrammedStatus(ctx, objectManifest)
+	if catchAllErr != nil {
+		logger.Error(catchAllErr, "Failed to compute CatchAllProgrammed status", "name", req.Name)
+	} else {
+		r.UpdateConditionCatchAllProgrammed(objectManifest, catchAllStatus)
+	}
+
 	return result, err
 }
 

--- a/internal/controller/customhttproute/status.go
+++ b/internal/controller/customhttproute/status.go
@@ -17,11 +17,15 @@ limitations under the License.
 package customhttproute
 
 import (
+	"context"
+	"fmt"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/freepik-company/customrouter/api/v1alpha1"
 	"github.com/freepik-company/customrouter/internal/controller"
+	ef "github.com/freepik-company/customrouter/internal/controller/envoyfilter"
 )
 
 // UpdateConditionReconciled sets the Reconciled condition to True
@@ -74,4 +78,63 @@ func (r *CustomHTTPRouteReconciler) UpdateConditionConfigMapFailed(object *v1alp
 		Reason:             controller.ConditionReasonConfigMapError,
 		Message:            msg,
 	})
+}
+
+// UpdateConditionCatchAllProgrammed sets the CatchAllProgrammed condition from the given evaluation result.
+func (r *CustomHTTPRouteReconciler) UpdateConditionCatchAllProgrammed(
+	object *v1alpha1.CustomHTTPRoute,
+	status ef.CatchAllProgrammedStatus,
+) {
+	condStatus := metav1.ConditionFalse
+	if status.Programmed {
+		condStatus = metav1.ConditionTrue
+	}
+	meta.SetStatusCondition(&object.Status.Conditions, metav1.Condition{
+		Type:               v1alpha1.ConditionTypeCatchAllProgrammed,
+		Status:             condStatus,
+		ObservedGeneration: object.Generation,
+		Reason:             status.Reason,
+		Message:            catchAllMessageFor(status.Reason),
+	})
+}
+
+// ComputeCatchAllProgrammedStatus resolves the CatchAllProgrammed state for a route by listing
+// the routes and EPAs needed to decide dedup and overrides. Returns NotConfigured without
+// any List call when the spec has no catchAllRoute.
+func (r *CustomHTTPRouteReconciler) ComputeCatchAllProgrammedStatus(
+	ctx context.Context,
+	route *v1alpha1.CustomHTTPRoute,
+) (ef.CatchAllProgrammedStatus, error) {
+	if route.Spec.CatchAllRoute == nil {
+		return ef.CatchAllProgrammedStatus{Reason: controller.ConditionReasonCatchAllNotConfigured}, nil
+	}
+
+	routeList := &v1alpha1.CustomHTTPRouteList{}
+	if err := r.List(ctx, routeList); err != nil {
+		return ef.CatchAllProgrammedStatus{}, fmt.Errorf("failed to list CustomHTTPRoutes: %w", err)
+	}
+
+	epaList := &v1alpha1.ExternalProcessorAttachmentList{}
+	if err := r.List(ctx, epaList); err != nil {
+		return ef.CatchAllProgrammedStatus{}, fmt.Errorf("failed to list ExternalProcessorAttachments: %w", err)
+	}
+
+	return ef.EvaluateCatchAllProgrammed(route, routeList, epaList), nil
+}
+
+func catchAllMessageFor(reason string) string {
+	switch reason {
+	case controller.ConditionReasonCatchAllProgrammed:
+		return controller.ConditionReasonCatchAllProgrammedMessage
+	case controller.ConditionReasonCatchAllNotConfigured:
+		return controller.ConditionReasonCatchAllNotConfiguredMessage
+	case controller.ConditionReasonCatchAllNoEPA:
+		return controller.ConditionReasonCatchAllNoEPAMessage
+	case controller.ConditionReasonCatchAllOverriddenByEPA:
+		return controller.ConditionReasonCatchAllOverriddenByEPAMessage
+	case controller.ConditionReasonCatchAllOverriddenByRoute:
+		return controller.ConditionReasonCatchAllOverriddenByRouteMessage
+	default:
+		return ""
+	}
 }

--- a/internal/controller/customhttproute/status_test.go
+++ b/internal/controller/customhttproute/status_test.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2024-2026 Freepik Company S.L.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package customhttproute
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/freepik-company/customrouter/api/v1alpha1"
+	"github.com/freepik-company/customrouter/internal/controller"
+	ef "github.com/freepik-company/customrouter/internal/controller/envoyfilter"
+)
+
+func newRouteWithCatchAll(namespace, name string, hostnames []string) v1alpha1.CustomHTTPRoute {
+	return v1alpha1.CustomHTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Spec: v1alpha1.CustomHTTPRouteSpec{
+			Hostnames: hostnames,
+			CatchAllRoute: &v1alpha1.CatchAllBackendRef{
+				BackendRef: v1alpha1.BackendRef{Name: "backend", Namespace: namespace, Port: 80},
+			},
+		},
+	}
+}
+
+func newEPAWithCatchAll(namespace, name string, hostnames []string) v1alpha1.ExternalProcessorAttachment {
+	return v1alpha1.ExternalProcessorAttachment{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Spec: v1alpha1.ExternalProcessorAttachmentSpec{
+			CatchAllRoute: &v1alpha1.CatchAllRouteConfig{
+				Hostnames:  hostnames,
+				BackendRef: v1alpha1.BackendRef{Name: "epa-backend", Namespace: namespace, Port: 80},
+			},
+		},
+	}
+}
+
+func TestEvaluateCatchAllProgrammed_NotConfigured(t *testing.T) {
+	route := &v1alpha1.CustomHTTPRoute{}
+	got := ef.EvaluateCatchAllProgrammed(route, &v1alpha1.CustomHTTPRouteList{}, &v1alpha1.ExternalProcessorAttachmentList{})
+	if got.Programmed || got.Reason != controller.ConditionReasonCatchAllNotConfigured {
+		t.Errorf("expected NotConfigured, got %+v", got)
+	}
+}
+
+func TestEvaluateCatchAllProgrammed_NoEPA(t *testing.T) {
+	route := newRouteWithCatchAll("ns", "r", []string{"a.com"})
+	routeList := &v1alpha1.CustomHTTPRouteList{Items: []v1alpha1.CustomHTTPRoute{route}}
+	got := ef.EvaluateCatchAllProgrammed(&route, routeList, &v1alpha1.ExternalProcessorAttachmentList{})
+	if got.Programmed || got.Reason != controller.ConditionReasonCatchAllNoEPA {
+		t.Errorf("expected NoExternalProcessor, got %+v", got)
+	}
+}
+
+func TestEvaluateCatchAllProgrammed_Programmed(t *testing.T) {
+	route := newRouteWithCatchAll("ns", "r", []string{"a.com", "b.com"})
+	routeList := &v1alpha1.CustomHTTPRouteList{Items: []v1alpha1.CustomHTTPRoute{route}}
+	epa := v1alpha1.ExternalProcessorAttachment{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "epa"}}
+	epaList := &v1alpha1.ExternalProcessorAttachmentList{Items: []v1alpha1.ExternalProcessorAttachment{epa}}
+
+	got := ef.EvaluateCatchAllProgrammed(&route, routeList, epaList)
+	if !got.Programmed || got.Reason != controller.ConditionReasonCatchAllProgrammed {
+		t.Fatalf("expected Programmed, got %+v", got)
+	}
+	if len(got.Hostnames) != 2 {
+		t.Errorf("expected 2 programmed hostnames, got %d", len(got.Hostnames))
+	}
+}
+
+func TestEvaluateCatchAllProgrammed_OverriddenByEPA(t *testing.T) {
+	route := newRouteWithCatchAll("ns", "r", []string{"a.com"})
+	routeList := &v1alpha1.CustomHTTPRouteList{Items: []v1alpha1.CustomHTTPRoute{route}}
+	epa := newEPAWithCatchAll("ns", "epa", []string{"a.com"})
+	epaList := &v1alpha1.ExternalProcessorAttachmentList{Items: []v1alpha1.ExternalProcessorAttachment{epa}}
+
+	got := ef.EvaluateCatchAllProgrammed(&route, routeList, epaList)
+	if got.Programmed || got.Reason != controller.ConditionReasonCatchAllOverriddenByEPA {
+		t.Errorf("expected OverriddenByEPA, got %+v", got)
+	}
+}
+
+func TestEvaluateCatchAllProgrammed_OverriddenByRoute(t *testing.T) {
+	winner := newRouteWithCatchAll("ns", "a-winner", []string{"a.com"})
+	loser := newRouteWithCatchAll("ns", "z-loser", []string{"a.com"})
+	routeList := &v1alpha1.CustomHTTPRouteList{Items: []v1alpha1.CustomHTTPRoute{winner, loser}}
+	epa := v1alpha1.ExternalProcessorAttachment{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "epa"}}
+	epaList := &v1alpha1.ExternalProcessorAttachmentList{Items: []v1alpha1.ExternalProcessorAttachment{epa}}
+
+	got := ef.EvaluateCatchAllProgrammed(&loser, routeList, epaList)
+	if got.Programmed || got.Reason != controller.ConditionReasonCatchAllOverriddenByRoute {
+		t.Errorf("expected OverriddenByRoute for loser, got %+v", got)
+	}
+
+	gotWinner := ef.EvaluateCatchAllProgrammed(&winner, routeList, epaList)
+	if !gotWinner.Programmed || gotWinner.Reason != controller.ConditionReasonCatchAllProgrammed {
+		t.Errorf("expected Programmed for winner, got %+v", gotWinner)
+	}
+}
+
+func TestEvaluateCatchAllProgrammed_MixedLossesFavorEPAReason(t *testing.T) {
+	// route loses "a.com" to another route and "b.com" to an EPA → OverriddenByEPA wins.
+	loser := newRouteWithCatchAll("ns", "z-loser", []string{"a.com", "b.com"})
+	winner := newRouteWithCatchAll("ns", "a-winner", []string{"a.com"})
+	routeList := &v1alpha1.CustomHTTPRouteList{Items: []v1alpha1.CustomHTTPRoute{winner, loser}}
+	epa := newEPAWithCatchAll("ns", "epa", []string{"b.com"})
+	epaList := &v1alpha1.ExternalProcessorAttachmentList{Items: []v1alpha1.ExternalProcessorAttachment{epa}}
+
+	got := ef.EvaluateCatchAllProgrammed(&loser, routeList, epaList)
+	if got.Programmed || got.Reason != controller.ConditionReasonCatchAllOverriddenByEPA {
+		t.Errorf("expected OverriddenByEPA with mixed losses, got %+v", got)
+	}
+}
+
+func TestUpdateConditionCatchAllProgrammed_TrueAndFalse(t *testing.T) {
+	r := &CustomHTTPRouteReconciler{}
+	object := &v1alpha1.CustomHTTPRoute{ObjectMeta: metav1.ObjectMeta{Generation: 7}}
+
+	r.UpdateConditionCatchAllProgrammed(object, ef.CatchAllProgrammedStatus{
+		Programmed: true,
+		Reason:     controller.ConditionReasonCatchAllProgrammed,
+	})
+	cond := meta.FindStatusCondition(object.Status.Conditions, v1alpha1.ConditionTypeCatchAllProgrammed)
+	if cond == nil {
+		t.Fatal("expected condition to be set")
+	}
+	if cond.Status != metav1.ConditionTrue {
+		t.Errorf("expected ConditionTrue, got %s", cond.Status)
+	}
+	if cond.Reason != controller.ConditionReasonCatchAllProgrammed {
+		t.Errorf("expected reason Programmed, got %s", cond.Reason)
+	}
+	if cond.Message != controller.ConditionReasonCatchAllProgrammedMessage {
+		t.Errorf("expected Programmed message, got %q", cond.Message)
+	}
+	if cond.ObservedGeneration != 7 {
+		t.Errorf("expected observedGeneration=7, got %d", cond.ObservedGeneration)
+	}
+
+	r.UpdateConditionCatchAllProgrammed(object, ef.CatchAllProgrammedStatus{
+		Reason: controller.ConditionReasonCatchAllOverriddenByRoute,
+	})
+	cond = meta.FindStatusCondition(object.Status.Conditions, v1alpha1.ConditionTypeCatchAllProgrammed)
+	if cond.Status != metav1.ConditionFalse {
+		t.Errorf("expected ConditionFalse after transition, got %s", cond.Status)
+	}
+	if cond.Reason != controller.ConditionReasonCatchAllOverriddenByRoute {
+		t.Errorf("expected reason OverriddenByRoute, got %s", cond.Reason)
+	}
+}
+
+func TestCatchAllMessageFor_AllReasons(t *testing.T) {
+	cases := map[string]string{
+		controller.ConditionReasonCatchAllProgrammed:        controller.ConditionReasonCatchAllProgrammedMessage,
+		controller.ConditionReasonCatchAllNotConfigured:     controller.ConditionReasonCatchAllNotConfiguredMessage,
+		controller.ConditionReasonCatchAllNoEPA:             controller.ConditionReasonCatchAllNoEPAMessage,
+		controller.ConditionReasonCatchAllOverriddenByEPA:   controller.ConditionReasonCatchAllOverriddenByEPAMessage,
+		controller.ConditionReasonCatchAllOverriddenByRoute: controller.ConditionReasonCatchAllOverriddenByRouteMessage,
+	}
+	for reason, want := range cases {
+		if got := catchAllMessageFor(reason); got != want {
+			t.Errorf("reason %q: expected %q, got %q", reason, want, got)
+		}
+	}
+	if got := catchAllMessageFor("Unknown"); got != "" {
+		t.Errorf("unknown reason should return empty string, got %q", got)
+	}
+}

--- a/internal/controller/customhttproute/status_test.go
+++ b/internal/controller/customhttproute/status_test.go
@@ -115,6 +115,33 @@ func TestEvaluateCatchAllProgrammed_OverriddenByRoute(t *testing.T) {
 	}
 }
 
+func TestEvaluateCatchAllProgrammed_OverrideOnSomeEPAsStillProgrammed(t *testing.T) {
+	// Route is overridden on EPA-1 but not on EPA-2 → still programmed because EPA-2 carries it.
+	route := newRouteWithCatchAll("r", []string{"a.com"})
+	routeList := &v1alpha1.CustomHTTPRouteList{Items: []v1alpha1.CustomHTTPRoute{route}}
+	epa1 := newEPAWithCatchAll("epa-1", []string{"a.com"})
+	epa2 := v1alpha1.ExternalProcessorAttachment{ObjectMeta: metav1.ObjectMeta{Namespace: testNS, Name: "epa-2"}}
+	epaList := &v1alpha1.ExternalProcessorAttachmentList{Items: []v1alpha1.ExternalProcessorAttachment{epa1, epa2}}
+
+	got := ef.EvaluateCatchAllProgrammed(&route, routeList, epaList)
+	if !got.Programmed || got.Reason != controller.ConditionReasonCatchAllProgrammed {
+		t.Errorf("expected Programmed because EPA-2 carries the route, got %+v", got)
+	}
+}
+
+func TestEvaluateCatchAllProgrammed_OverrideOnAllEPAsIsOverridden(t *testing.T) {
+	route := newRouteWithCatchAll("r", []string{"a.com"})
+	routeList := &v1alpha1.CustomHTTPRouteList{Items: []v1alpha1.CustomHTTPRoute{route}}
+	epa1 := newEPAWithCatchAll("epa-1", []string{"a.com"})
+	epa2 := newEPAWithCatchAll("epa-2", []string{"a.com"})
+	epaList := &v1alpha1.ExternalProcessorAttachmentList{Items: []v1alpha1.ExternalProcessorAttachment{epa1, epa2}}
+
+	got := ef.EvaluateCatchAllProgrammed(&route, routeList, epaList)
+	if got.Programmed || got.Reason != controller.ConditionReasonCatchAllOverriddenByEPA {
+		t.Errorf("expected OverriddenByEPA when every EPA overrides, got %+v", got)
+	}
+}
+
 func TestEvaluateCatchAllProgrammed_MixedLossesFavorEPAReason(t *testing.T) {
 	// route loses "a.com" to another route and "b.com" to an EPA → OverriddenByEPA wins.
 	loser := newRouteWithCatchAll("z-loser", []string{"a.com", "b.com"})

--- a/internal/controller/customhttproute/status_test.go
+++ b/internal/controller/customhttproute/status_test.go
@@ -27,25 +27,27 @@ import (
 	ef "github.com/freepik-company/customrouter/internal/controller/envoyfilter"
 )
 
-func newRouteWithCatchAll(namespace, name string, hostnames []string) v1alpha1.CustomHTTPRoute {
+const testNS = "ns"
+
+func newRouteWithCatchAll(name string, hostnames []string) v1alpha1.CustomHTTPRoute {
 	return v1alpha1.CustomHTTPRoute{
-		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNS, Name: name},
 		Spec: v1alpha1.CustomHTTPRouteSpec{
 			Hostnames: hostnames,
 			CatchAllRoute: &v1alpha1.CatchAllBackendRef{
-				BackendRef: v1alpha1.BackendRef{Name: "backend", Namespace: namespace, Port: 80},
+				BackendRef: v1alpha1.BackendRef{Name: "backend", Namespace: testNS, Port: 80},
 			},
 		},
 	}
 }
 
-func newEPAWithCatchAll(namespace, name string, hostnames []string) v1alpha1.ExternalProcessorAttachment {
+func newEPAWithCatchAll(name string, hostnames []string) v1alpha1.ExternalProcessorAttachment {
 	return v1alpha1.ExternalProcessorAttachment{
-		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNS, Name: name},
 		Spec: v1alpha1.ExternalProcessorAttachmentSpec{
 			CatchAllRoute: &v1alpha1.CatchAllRouteConfig{
 				Hostnames:  hostnames,
-				BackendRef: v1alpha1.BackendRef{Name: "epa-backend", Namespace: namespace, Port: 80},
+				BackendRef: v1alpha1.BackendRef{Name: "epa-backend", Namespace: testNS, Port: 80},
 			},
 		},
 	}
@@ -60,7 +62,7 @@ func TestEvaluateCatchAllProgrammed_NotConfigured(t *testing.T) {
 }
 
 func TestEvaluateCatchAllProgrammed_NoEPA(t *testing.T) {
-	route := newRouteWithCatchAll("ns", "r", []string{"a.com"})
+	route := newRouteWithCatchAll("r", []string{"a.com"})
 	routeList := &v1alpha1.CustomHTTPRouteList{Items: []v1alpha1.CustomHTTPRoute{route}}
 	got := ef.EvaluateCatchAllProgrammed(&route, routeList, &v1alpha1.ExternalProcessorAttachmentList{})
 	if got.Programmed || got.Reason != controller.ConditionReasonCatchAllNoEPA {
@@ -69,7 +71,7 @@ func TestEvaluateCatchAllProgrammed_NoEPA(t *testing.T) {
 }
 
 func TestEvaluateCatchAllProgrammed_Programmed(t *testing.T) {
-	route := newRouteWithCatchAll("ns", "r", []string{"a.com", "b.com"})
+	route := newRouteWithCatchAll("r", []string{"a.com", "b.com"})
 	routeList := &v1alpha1.CustomHTTPRouteList{Items: []v1alpha1.CustomHTTPRoute{route}}
 	epa := v1alpha1.ExternalProcessorAttachment{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "epa"}}
 	epaList := &v1alpha1.ExternalProcessorAttachmentList{Items: []v1alpha1.ExternalProcessorAttachment{epa}}
@@ -84,9 +86,9 @@ func TestEvaluateCatchAllProgrammed_Programmed(t *testing.T) {
 }
 
 func TestEvaluateCatchAllProgrammed_OverriddenByEPA(t *testing.T) {
-	route := newRouteWithCatchAll("ns", "r", []string{"a.com"})
+	route := newRouteWithCatchAll("r", []string{"a.com"})
 	routeList := &v1alpha1.CustomHTTPRouteList{Items: []v1alpha1.CustomHTTPRoute{route}}
-	epa := newEPAWithCatchAll("ns", "epa", []string{"a.com"})
+	epa := newEPAWithCatchAll("epa", []string{"a.com"})
 	epaList := &v1alpha1.ExternalProcessorAttachmentList{Items: []v1alpha1.ExternalProcessorAttachment{epa}}
 
 	got := ef.EvaluateCatchAllProgrammed(&route, routeList, epaList)
@@ -96,8 +98,8 @@ func TestEvaluateCatchAllProgrammed_OverriddenByEPA(t *testing.T) {
 }
 
 func TestEvaluateCatchAllProgrammed_OverriddenByRoute(t *testing.T) {
-	winner := newRouteWithCatchAll("ns", "a-winner", []string{"a.com"})
-	loser := newRouteWithCatchAll("ns", "z-loser", []string{"a.com"})
+	winner := newRouteWithCatchAll("a-winner", []string{"a.com"})
+	loser := newRouteWithCatchAll("z-loser", []string{"a.com"})
 	routeList := &v1alpha1.CustomHTTPRouteList{Items: []v1alpha1.CustomHTTPRoute{winner, loser}}
 	epa := v1alpha1.ExternalProcessorAttachment{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "epa"}}
 	epaList := &v1alpha1.ExternalProcessorAttachmentList{Items: []v1alpha1.ExternalProcessorAttachment{epa}}
@@ -115,10 +117,10 @@ func TestEvaluateCatchAllProgrammed_OverriddenByRoute(t *testing.T) {
 
 func TestEvaluateCatchAllProgrammed_MixedLossesFavorEPAReason(t *testing.T) {
 	// route loses "a.com" to another route and "b.com" to an EPA → OverriddenByEPA wins.
-	loser := newRouteWithCatchAll("ns", "z-loser", []string{"a.com", "b.com"})
-	winner := newRouteWithCatchAll("ns", "a-winner", []string{"a.com"})
+	loser := newRouteWithCatchAll("z-loser", []string{"a.com", "b.com"})
+	winner := newRouteWithCatchAll("a-winner", []string{"a.com"})
 	routeList := &v1alpha1.CustomHTTPRouteList{Items: []v1alpha1.CustomHTTPRoute{winner, loser}}
-	epa := newEPAWithCatchAll("ns", "epa", []string{"b.com"})
+	epa := newEPAWithCatchAll("epa", []string{"b.com"})
 	epaList := &v1alpha1.ExternalProcessorAttachmentList{Items: []v1alpha1.ExternalProcessorAttachment{epa}}
 
 	got := ef.EvaluateCatchAllProgrammed(&loser, routeList, epaList)

--- a/internal/controller/envoyfilter/envoyfilter.go
+++ b/internal/controller/envoyfilter/envoyfilter.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/freepik-company/customrouter/api/v1alpha1"
+	"github.com/freepik-company/customrouter/internal/controller"
 )
 
 const (
@@ -148,9 +149,28 @@ func DeleteEnvoyFilter(ctx context.Context, cl client.Client, key types.Namespac
 }
 
 // CollectCatchAllEntries extracts catch-all entries from all CustomHTTPRoutes that declare catchAllRoute.
+// When multiple routes declare the same hostname, the first one in lexicographic order of
+// namespace/name wins, ensuring a deterministic result across reconciliations.
 func CollectCatchAllEntries(routeList *v1alpha1.CustomHTTPRouteList) []CatchAllEntry {
 	hostnameMap := make(map[string]v1alpha1.BackendRef)
 
+	ordered := orderedRoutesWithCatchAll(routeList)
+	for _, route := range ordered {
+		for _, hostname := range route.Spec.Hostnames {
+			if _, exists := hostnameMap[hostname]; exists {
+				continue
+			}
+			hostnameMap[hostname] = route.Spec.CatchAllRoute.BackendRef
+		}
+	}
+
+	return sortedEntries(hostnameMap)
+}
+
+// orderedRoutesWithCatchAll returns non-deleting routes with a non-nil catchAllRoute,
+// sorted by "namespace/name" to provide a stable iteration order for dedup decisions.
+func orderedRoutesWithCatchAll(routeList *v1alpha1.CustomHTTPRouteList) []*v1alpha1.CustomHTTPRoute {
+	out := make([]*v1alpha1.CustomHTTPRoute, 0, len(routeList.Items))
 	for i := range routeList.Items {
 		route := &routeList.Items[i]
 		if route.DeletionTimestamp != nil && !route.DeletionTimestamp.IsZero() {
@@ -159,12 +179,16 @@ func CollectCatchAllEntries(routeList *v1alpha1.CustomHTTPRouteList) []CatchAllE
 		if route.Spec.CatchAllRoute == nil {
 			continue
 		}
-		for _, hostname := range route.Spec.Hostnames {
-			hostnameMap[hostname] = route.Spec.CatchAllRoute.BackendRef
-		}
+		out = append(out, route)
 	}
+	sort.Slice(out, func(i, j int) bool {
+		return routeKey(out[i]) < routeKey(out[j])
+	})
+	return out
+}
 
-	return sortedEntries(hostnameMap)
+func routeKey(route *v1alpha1.CustomHTTPRoute) string {
+	return route.Namespace + "/" + route.Name
 }
 
 // MergeCatchAllEntries merges entries from CustomHTTPRoutes with the EPA's own catchAllRoute config.
@@ -270,6 +294,95 @@ func buildCatchAllPatch(entry CatchAllEntry) map[string]interface{} {
 			},
 		},
 	}
+}
+
+// CatchAllProgrammedStatus describes whether a CustomHTTPRoute's catchAllRoute ends up
+// applied on at least one EPA's catch-all EnvoyFilter, and if not, which reason prevails.
+type CatchAllProgrammedStatus struct {
+	Programmed bool
+	Reason     string
+	Hostnames  []string // hostnames of the route that won both dedup and EPA override (when Programmed=true)
+}
+
+// EvaluateCatchAllProgrammed determines the programming state of a route's catchAllRoute.
+// The result's Reason is one of the ConditionReasonCatchAll* constants from the controller package.
+func EvaluateCatchAllProgrammed(
+	route *v1alpha1.CustomHTTPRoute,
+	routeList *v1alpha1.CustomHTTPRouteList,
+	epaList *v1alpha1.ExternalProcessorAttachmentList,
+) CatchAllProgrammedStatus {
+	if route == nil || route.Spec.CatchAllRoute == nil {
+		return CatchAllProgrammedStatus{Reason: controller.ConditionReasonCatchAllNotConfigured}
+	}
+
+	if epaList == nil || len(epaList.Items) == 0 {
+		return CatchAllProgrammedStatus{Reason: controller.ConditionReasonCatchAllNoEPA}
+	}
+
+	selfKey := routeKey(route)
+	var wonHostnames, lostByRoute []string
+	for _, hostname := range route.Spec.Hostnames {
+		if winnerHostnameRoute(hostname, routeList) == selfKey {
+			wonHostnames = append(wonHostnames, hostname)
+		} else {
+			lostByRoute = append(lostByRoute, hostname)
+		}
+	}
+
+	var programmed, lostByEPA []string
+	for _, hostname := range wonHostnames {
+		if hostnameOverriddenByAnyEPA(hostname, epaList) {
+			lostByEPA = append(lostByEPA, hostname)
+		} else {
+			programmed = append(programmed, hostname)
+		}
+	}
+
+	if len(programmed) > 0 {
+		return CatchAllProgrammedStatus{
+			Programmed: true,
+			Reason:     controller.ConditionReasonCatchAllProgrammed,
+			Hostnames:  programmed,
+		}
+	}
+
+	if len(lostByEPA) > 0 {
+		return CatchAllProgrammedStatus{Reason: controller.ConditionReasonCatchAllOverriddenByEPA}
+	}
+	return CatchAllProgrammedStatus{Reason: controller.ConditionReasonCatchAllOverriddenByRoute}
+}
+
+// winnerHostnameRoute returns the namespace/name of the route that wins the dedup for hostname,
+// or "" if no route declares it. The winner is the first in lexicographic order of namespace/name.
+func winnerHostnameRoute(hostname string, routeList *v1alpha1.CustomHTTPRouteList) string {
+	if routeList == nil {
+		return ""
+	}
+	ordered := orderedRoutesWithCatchAll(routeList)
+	for _, r := range ordered {
+		for _, h := range r.Spec.Hostnames {
+			if h == hostname {
+				return routeKey(r)
+			}
+		}
+	}
+	return ""
+}
+
+// hostnameOverriddenByAnyEPA reports whether at least one EPA's own catchAllRoute.Hostnames contains hostname.
+func hostnameOverriddenByAnyEPA(hostname string, epaList *v1alpha1.ExternalProcessorAttachmentList) bool {
+	for i := range epaList.Items {
+		epa := &epaList.Items[i]
+		if epa.Spec.CatchAllRoute == nil {
+			continue
+		}
+		for _, h := range epa.Spec.CatchAllRoute.Hostnames {
+			if h == hostname {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // sortedEntries converts a hostname→BackendRef map to a sorted slice of CatchAllEntry.

--- a/internal/controller/envoyfilter/envoyfilter.go
+++ b/internal/controller/envoyfilter/envoyfilter.go
@@ -329,7 +329,10 @@ func EvaluateCatchAllProgrammed(
 
 	var programmed, lostByEPA []string
 	for _, hostname := range wonHostnames {
-		if hostnameOverriddenByAnyEPA(hostname, epaList) {
+		// A hostname is lost only if every EPA overrides it, because each EPA produces
+		// its own catch-all EnvoyFilter: the route's catch-all still reaches the dataplane
+		// through any EPA that does not declare the hostname in its own catchAllRoute.
+		if hostnameOverriddenByEveryEPA(hostname, epaList) {
 			lostByEPA = append(lostByEPA, hostname)
 		} else {
 			programmed = append(programmed, hostname)
@@ -367,20 +370,30 @@ func winnerHostnameRoute(hostname string, routeList *v1alpha1.CustomHTTPRouteLis
 	return ""
 }
 
-// hostnameOverriddenByAnyEPA reports whether at least one EPA's own catchAllRoute.Hostnames contains hostname.
-func hostnameOverriddenByAnyEPA(hostname string, epaList *v1alpha1.ExternalProcessorAttachmentList) bool {
+// hostnameOverriddenByEveryEPA reports whether every EPA declares hostname in its own
+// catchAllRoute.Hostnames. Returns false if any EPA has no catchAllRoute or does not declare
+// the hostname, because that EPA will carry the route's catch-all through to the dataplane.
+func hostnameOverriddenByEveryEPA(hostname string, epaList *v1alpha1.ExternalProcessorAttachmentList) bool {
+	if epaList == nil || len(epaList.Items) == 0 {
+		return false
+	}
 	for i := range epaList.Items {
 		epa := &epaList.Items[i]
 		if epa.Spec.CatchAllRoute == nil {
-			continue
+			return false
 		}
+		found := false
 		for _, h := range epa.Spec.CatchAllRoute.Hostnames {
 			if h == hostname {
-				return true
+				found = true
+				break
 			}
 		}
+		if !found {
+			return false
+		}
 	}
-	return false
+	return true
 }
 
 // sortedEntries converts a hostname→BackendRef map to a sorted slice of CatchAllEntry.

--- a/internal/controller/envoyfilter/envoyfilter.go
+++ b/internal/controller/envoyfilter/envoyfilter.go
@@ -320,12 +320,10 @@ func EvaluateCatchAllProgrammed(
 	}
 
 	selfKey := routeKey(route)
-	var wonHostnames, lostByRoute []string
+	var wonHostnames []string
 	for _, hostname := range route.Spec.Hostnames {
 		if winnerHostnameRoute(hostname, routeList) == selfKey {
 			wonHostnames = append(wonHostnames, hostname)
-		} else {
-			lostByRoute = append(lostByRoute, hostname)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Adds a new `CatchAllProgrammed` status condition on `CustomHTTPRoute` that reflects whether the spec's `catchAllRoute` reaches the dataplane, with five discriminating reasons (`Programmed`, `NotConfigured`, `NoExternalProcessor`, `OverriddenByEPA`, `OverriddenByRoute`).
- Surfaces the reason as a new `CatchAll` printer column in the CRD for quick visibility from `kubectl get`.
- Makes `CollectCatchAllEntries` deterministic: when multiple routes declare the same hostname, the first one in lexicographic order of `namespace/name` wins instead of relying on map iteration order.

## Test plan
- [x] `go build ./...`
- [x] `make fmt vet`
- [x] `go test ./api/... ./internal/controller/...`
- [ ] Apply a route with `catchAllRoute` + an EPA and verify `kubectl get customhttproutes` shows `CATCHALL=Programmed`.
- [ ] Delete all EPAs and verify reason flips to `NoExternalProcessor`.
- [ ] Add an EPA with its own `catchAllRoute` for the same hostname and verify reason becomes `OverriddenByEPA`.
- [ ] Create two routes with `catchAllRoute` sharing a hostname and verify only the lexicographically-first one is `Programmed`, the other is `OverriddenByRoute`.
- [ ] Verify a route without `catchAllRoute` gets `NotConfigured`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new controller status evaluation that lists all `CustomHTTPRoute`s and `ExternalProcessorAttachment`s and changes catch-all hostname dedup behavior to deterministic lexicographic-first wins, which can alter which backend is programmed in conflicting setups.
> 
> **Overview**
> Adds a new `CatchAllProgrammed` status condition on `CustomHTTPRoute` (with printer column `CatchAll`) to surface whether a route’s `spec.catchAllRoute` actually reaches the dataplane, including distinct reasons like *not configured*, *no EPA*, or *overridden*.
> 
> The reconciler now computes and updates this condition after successful reconciliation by evaluating route dedup and per-EPA overrides via new `envoyfilter.EvaluateCatchAllProgrammed` logic.
> 
> Makes catch-all hostname dedup deterministic by sorting routes by `namespace/name` and selecting the lexicographically-first route for a shared hostname (updating tests accordingly and adding new unit tests for the programmed/override reasons).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 487786c528d0845840ab12e10c4e7ea48c54ea8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->