### PR TITLE
feat(catchall): coexist with HTTPRoute on same hostname (0.6.1)

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: customrouter
 description: A Helm chart for CustomRouter - Kubernetes operator and external processor for dynamic HTTP routing
 type: application
-version: 0.6.0
-appVersion: "0.6.0"
+version: 0.6.1
+appVersion: "0.6.1"
 kubeVersion: ">= 1.26.0-0"
 keywords:
   - kubernetes

--- a/internal/controller/customhttproute/catchall.go
+++ b/internal/controller/customhttproute/catchall.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/freepik-company/customrouter/api/v1alpha1"
 	ef "github.com/freepik-company/customrouter/internal/controller/envoyfilter"
@@ -51,6 +52,11 @@ func (r *CustomHTTPRouteReconciler) reconcileCatchAllFromRoutes(
 		return nil
 	}
 
+	httpRouteList := &gatewayv1.HTTPRouteList{}
+	if err := r.List(ctx, httpRouteList); err != nil {
+		return fmt.Errorf("failed to list HTTPRoutes: %w", err)
+	}
+
 	for i := range epaList.Items {
 		epa := &epaList.Items[i]
 
@@ -67,7 +73,13 @@ func (r *CustomHTTPRouteReconciler) reconcileCatchAllFromRoutes(
 			continue
 		}
 
-		envoyFilter, err := ef.BuildCatchAllEnvoyFilter(epa, merged)
+		hostnames := make([]string, 0, len(merged))
+		for _, e := range merged {
+			hostnames = append(hostnames, e.Hostname)
+		}
+		hostnamesWithHTTPRoute := ef.CollectHostnamesWithHTTPRoute(httpRouteList, hostnames)
+
+		envoyFilter, err := ef.BuildCatchAllEnvoyFilter(epa, merged, hostnamesWithHTTPRoute)
 		if err != nil {
 			return fmt.Errorf("failed to build catch-all EnvoyFilter for EPA %s/%s: %w",
 				epa.Namespace, epa.Name, err)

--- a/internal/controller/customhttproute/controller.go
+++ b/internal/controller/customhttproute/controller.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	crv1alpha1 "github.com/freepik-company/customrouter/api/v1alpha1"
 	"github.com/freepik-company/customrouter/internal/controller"
@@ -53,6 +54,7 @@ type CustomHTTPRouteReconciler struct {
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch
 // +kubebuilder:rbac:groups=networking.istio.io,resources=envoyfilters,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -171,6 +173,7 @@ func (r *CustomHTTPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&crv1alpha1.CustomHTTPRoute{}).
 		Watches(&corev1.Service{}, handler.EnqueueRequestsFromMapFunc(r.findRoutesForService)).
+		Watches(&gatewayv1.HTTPRoute{}, handler.EnqueueRequestsFromMapFunc(r.findRoutesForHTTPRoute)).
 		WithOptions(ctrlcontroller.Options{MaxConcurrentReconciles: maxConcurrent}).
 		Named("customhttproute").
 		Complete(r)
@@ -212,4 +215,44 @@ func routeReferencesService(route *crv1alpha1.CustomHTTPRoute, svcName, svcNames
 		}
 	}
 	return false
+}
+
+// findRoutesForHTTPRoute enqueues CustomHTTPRoutes whose catchAllRoute covers a hostname
+// that the given HTTPRoute declares. A HTTPRoute create/update/delete can flip whether
+// the catchall EnvoyFilter must ADD a new virtual host or inject into an existing one,
+// so those CustomHTTPRoutes need re-reconciliation.
+func (r *CustomHTTPRouteReconciler) findRoutesForHTTPRoute(ctx context.Context, obj client.Object) []reconcile.Request {
+	hr, ok := obj.(*gatewayv1.HTTPRoute)
+	if !ok || len(hr.Spec.Hostnames) == 0 {
+		return nil
+	}
+	hostSet := make(map[string]struct{}, len(hr.Spec.Hostnames))
+	for _, h := range hr.Spec.Hostnames {
+		hostSet[string(h)] = struct{}{}
+	}
+
+	routeList := &crv1alpha1.CustomHTTPRouteList{}
+	if err := r.List(ctx, routeList); err != nil {
+		return nil
+	}
+
+	var requests []reconcile.Request
+	for i := range routeList.Items {
+		route := &routeList.Items[i]
+		if route.Spec.CatchAllRoute == nil {
+			continue
+		}
+		for _, h := range route.Spec.Hostnames {
+			if _, match := hostSet[h]; match {
+				requests = append(requests, reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Name:      route.Name,
+						Namespace: route.Namespace,
+					},
+				})
+				break
+			}
+		}
+	}
+	return requests
 }

--- a/internal/controller/envoyfilter/envoyfilter.go
+++ b/internal/controller/envoyfilter/envoyfilter.go
@@ -32,10 +32,17 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/freepik-company/customrouter/api/v1alpha1"
 	"github.com/freepik-company/customrouter/internal/controller"
 )
+
+// DefaultCatchAllPorts are the listener ports against which HTTP_ROUTE INSERT_FIRST
+// patches are emitted when a hostname is already covered by an HTTPRoute. Patches
+// targeting a non-existing (hostname, port) virtual host are silently ignored by
+// Istio, so emitting both is safe.
+var DefaultCatchAllPorts = []int{80, 443}
 
 const (
 	// EnvoyFilter name suffixes
@@ -209,10 +216,39 @@ func MergeCatchAllEntries(routeEntries []CatchAllEntry, epa *v1alpha1.ExternalPr
 	return sortedEntries(merged)
 }
 
+// CollectHostnamesWithHTTPRoute returns the subset of the given hostnames that are
+// also declared in any existing HTTPRoute. This drives per-hostname selection between
+// "ADD a virtual host" (no HTTPRoute exists) and "inject into the existing virtual host"
+// (HTTPRoute exists and already owns the domain).
+func CollectHostnamesWithHTTPRoute(httpRouteList *gatewayv1.HTTPRouteList, hostnames []string) map[string]bool {
+	out := map[string]bool{}
+	if httpRouteList == nil || len(hostnames) == 0 {
+		return out
+	}
+	target := make(map[string]struct{}, len(hostnames))
+	for _, h := range hostnames {
+		target[h] = struct{}{}
+	}
+	for i := range httpRouteList.Items {
+		hr := &httpRouteList.Items[i]
+		for _, h := range hr.Spec.Hostnames {
+			if _, ok := target[string(h)]; ok {
+				out[string(h)] = true
+			}
+		}
+	}
+	return out
+}
+
 // BuildCatchAllEnvoyFilter builds the catch-all EnvoyFilter unstructured object.
+// For each hostname the emitted patch depends on whether an HTTPRoute already owns
+// the domain (see hostnamesWithHTTPRoute): if yes, HTTP_ROUTE INSERT_FIRST patches
+// inject the fallback into the existing virtual host (avoids Envoy's "Duplicate entry
+// of domain" error); otherwise the legacy VIRTUAL_HOST ADD creates a new virtual host.
 func BuildCatchAllEnvoyFilter(
 	epa *v1alpha1.ExternalProcessorAttachment,
 	entries []CatchAllEntry,
+	hostnamesWithHTTPRoute map[string]bool,
 ) (*unstructured.Unstructured, error) {
 	filterName := epa.Name + CatchAllFilterSuffix
 
@@ -227,7 +263,9 @@ func BuildCatchAllEnvoyFilter(
 
 	configPatches := make([]interface{}, 0, len(entries))
 	for _, entry := range entries {
-		configPatches = append(configPatches, buildCatchAllPatch(entry))
+		for _, patch := range buildCatchAllPatches(entry, hostnamesWithHTTPRoute[entry.Hostname]) {
+			configPatches = append(configPatches, patch)
+		}
 	}
 
 	spec := map[string]interface{}{
@@ -244,8 +282,25 @@ func BuildCatchAllEnvoyFilter(
 	return ef, nil
 }
 
-// buildCatchAllPatch builds a single VIRTUAL_HOST config patch for a catch-all entry.
-func buildCatchAllPatch(entry CatchAllEntry) map[string]interface{} {
+// buildCatchAllPatches returns the config patches for one hostname. When no HTTPRoute
+// owns the domain, one VIRTUAL_HOST ADD is returned. When an HTTPRoute already owns
+// the domain, one HTTP_ROUTE INSERT_FIRST per port in DefaultCatchAllPorts is returned
+// — Envoy would reject a second virtual host with the same domain, so the fallback is
+// injected into the existing one instead.
+func buildCatchAllPatches(entry CatchAllEntry, hostnameHasHTTPRoute bool) []map[string]interface{} {
+	if !hostnameHasHTTPRoute {
+		return []map[string]interface{}{buildCatchAllVirtualHostPatch(entry)}
+	}
+	patches := make([]map[string]interface{}, 0, len(DefaultCatchAllPorts))
+	for _, port := range DefaultCatchAllPorts {
+		patches = append(patches, buildCatchAllHTTPRoutePatch(entry, port))
+	}
+	return patches
+}
+
+// buildCatchAllVirtualHostPatch builds the legacy VIRTUAL_HOST ADD patch, creating a
+// new virtual host with both the header-gated dynamic route and the default fallback.
+func buildCatchAllVirtualHostPatch(entry CatchAllEntry) map[string]interface{} {
 	clusterName := BuildClusterName(entry.BackendRef)
 
 	return map[string]interface{}{
@@ -290,6 +345,39 @@ func buildCatchAllPatch(entry CatchAllEntry) map[string]interface{} {
 							"timeout": "30s",
 						},
 					},
+				},
+			},
+		},
+	}
+}
+
+// buildCatchAllHTTPRoutePatch injects only the default fallback route at the top of
+// the virtual host "<hostname>:<port>" (owned by the HTTPRoute). The header-gated
+// dynamic route is already injected into every virtual host by the <epa>-routes
+// EnvoyFilter, so duplicating it here would be redundant.
+func buildCatchAllHTTPRoutePatch(entry CatchAllEntry, port int) map[string]interface{} {
+	clusterName := BuildClusterName(entry.BackendRef)
+
+	return map[string]interface{}{
+		"applyTo": "HTTP_ROUTE",
+		"match": map[string]interface{}{
+			"context": "GATEWAY",
+			"routeConfiguration": map[string]interface{}{
+				"vhost": map[string]interface{}{
+					"name": fmt.Sprintf("%s:%d", entry.Hostname, port),
+				},
+			},
+		},
+		"patch": map[string]interface{}{
+			"operation": "INSERT_FIRST",
+			"value": map[string]interface{}{
+				"name": fmt.Sprintf("customrouter-catchall-%s", entry.Hostname),
+				"match": map[string]interface{}{
+					"prefix": "/",
+				},
+				"route": map[string]interface{}{
+					"cluster": clusterName,
+					"timeout": "30s",
 				},
 			},
 		},

--- a/internal/controller/externalprocessorattachment/controller.go
+++ b/internal/controller/externalprocessorattachment/controller.go
@@ -20,10 +20,14 @@ import (
 	"context"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	crv1alpha1 "github.com/freepik-company/customrouter/api/v1alpha1"
 	"github.com/freepik-company/customrouter/internal/controller"
@@ -40,6 +44,7 @@ type ExternalProcessorAttachmentReconciler struct {
 // +kubebuilder:rbac:groups=customrouter.freepik.com,resources=externalprocessorattachments/finalizers,verbs=update
 // +kubebuilder:rbac:groups=customrouter.freepik.com,resources=customhttproutes,verbs=get;list;watch
 // +kubebuilder:rbac:groups=networking.istio.io,resources=envoyfilters,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -118,6 +123,29 @@ func (r *ExternalProcessorAttachmentReconciler) Reconcile(ctx context.Context, r
 func (r *ExternalProcessorAttachmentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&crv1alpha1.ExternalProcessorAttachment{}).
+		Watches(&gatewayv1.HTTPRoute{}, handler.EnqueueRequestsFromMapFunc(r.findEPAsForHTTPRoute)).
 		Named("externalprocessorattachment").
 		Complete(r)
+}
+
+// findEPAsForHTTPRoute enqueues every EPA when an HTTPRoute changes. HTTPRoute
+// create/update/delete can flip whether the EPA's catchall EnvoyFilter must ADD a
+// new virtual host or inject into an existing one. The blast radius is contained by
+// the fact that there are typically only a handful of EPAs per cluster.
+func (r *ExternalProcessorAttachmentReconciler) findEPAsForHTTPRoute(ctx context.Context, _ client.Object) []reconcile.Request {
+	epaList := &crv1alpha1.ExternalProcessorAttachmentList{}
+	if err := r.List(ctx, epaList); err != nil {
+		return nil
+	}
+	requests := make([]reconcile.Request, 0, len(epaList.Items))
+	for i := range epaList.Items {
+		epa := &epaList.Items[i]
+		requests = append(requests, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      epa.Name,
+				Namespace: epa.Namespace,
+			},
+		})
+	}
+	return requests
 }

--- a/internal/controller/externalprocessorattachment/sync.go
+++ b/internal/controller/externalprocessorattachment/sync.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/freepik-company/customrouter/api/v1alpha1"
 	ef "github.com/freepik-company/customrouter/internal/controller/envoyfilter"
@@ -50,7 +51,17 @@ func (r *ExternalProcessorAttachmentReconciler) reconcileEnvoyFilters(
 	mergedEntries := r.collectMergedCatchAllEntries(ctx, attachment)
 
 	if len(mergedEntries) > 0 {
-		envoyFilter, err := ef.BuildCatchAllEnvoyFilter(attachment, mergedEntries)
+		hostnames := make([]string, 0, len(mergedEntries))
+		for _, e := range mergedEntries {
+			hostnames = append(hostnames, e.Hostname)
+		}
+		httpRouteList := &gatewayv1.HTTPRouteList{}
+		if err := r.List(ctx, httpRouteList); err != nil {
+			return fmt.Errorf("failed to list HTTPRoutes: %w", err)
+		}
+		hostnamesWithHTTPRoute := ef.CollectHostnamesWithHTTPRoute(httpRouteList, hostnames)
+
+		envoyFilter, err := ef.BuildCatchAllEnvoyFilter(attachment, mergedEntries, hostnamesWithHTTPRoute)
 		if err != nil {
 			return fmt.Errorf("failed to build catch-all EnvoyFilter: %w", err)
 		}


### PR DESCRIPTION
## Summary

- When a `CustomHTTPRoute.catchAllRoute` and an `HTTPRoute` target the same hostname, the catchall EnvoyFilter no longer emits a `VIRTUAL_HOST ADD` (which Envoy silently rejected with *"Only unique values for domains are permitted"*, leaving the outcome tied to the order Istio happened to process the resources). It instead emits `HTTP_ROUTE INSERT_FIRST` against `<hostname>:80/:443`, injecting the default fallback at the top of the existing virtual host.
- Both the CustomHTTPRoute and ExternalProcessorAttachment controllers now watch `HTTPRoute`, so the catchall EnvoyFilter is re-reconciled when HTTPRoutes appear, change, or disappear.
- Per-hostname decision: `www.example.com` (no HTTPRoute) can keep the `VIRTUAL_HOST ADD` path while `example.com` (has HTTPRoute) uses `HTTP_ROUTE INSERT_FIRST` in the same filter.
- Chart bumped to `0.6.1`.

## Why

Previously, whether the catch-all "won" over an HTTPRoute with the same hostname depended entirely on which resource Istio processed first — silently. On a restart of istiod, a recreated EPA, or an upgrade, the winner could flip and the HTTPRoute would start receiving traffic the operator was supposed to cover. The new approach makes catch-all precedence deterministic while leaving the HTTPRoute resource itself untouched.

## Test plan

Verified on a local kind cluster (Istio 1.24, Gateway API v1):

- [x] **Case A — no HTTPRoute on the hostname**: catchall EnvoyFilter emits `VIRTUAL_HOST ADD` (unchanged behaviour). `/` returns the catchAll backend.
- [x] **Case B — HTTPRoute added on the same hostname**: watch fires, catchall regenerates with two `HTTP_ROUTE INSERT_FIRST` patches per hostname (:80/:443). `/legacy/foo`, `/httproute-only`, `/`, `/random` all route to the catchAll backend; the HTTPRoute is shadowed. No `Duplicate entry of domain` in istiod logs.
- [x] **Case C — HTTPRoute removed**: watch fires, catchall reverts to `VIRTUAL_HOST ADD`. Catch-all keeps serving.
- [x] **Mixed hostnames**: within the same EnvoyFilter, `example.com` uses HTTP_ROUTE INSERT_FIRST while `www.example.com` keeps VIRTUAL_HOST ADD.
- [x] `go test ./...` passes.
- [x] `go build ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how gateway routing is patched at runtime and adds new controller watch/reconcile triggers, which could affect traffic routing if match/port assumptions differ across Istio/Gateway configurations.
> 
> **Overview**
> Catch-all EnvoyFilter generation is now **HTTPRoute-aware**: for hostnames already claimed by a Gateway API `HTTPRoute`, the controller emits `HTTP_ROUTE` `INSERT_FIRST` patches (for ports `80`/`443`) instead of `VIRTUAL_HOST` `ADD`, avoiding Envoy “duplicate domain” rejection and making precedence deterministic per-hostname.
> 
> Both the `CustomHTTPRoute` and `ExternalProcessorAttachment` controllers now watch `gateway.networking.k8s.io/HTTPRoute` and re-reconcile catch-all filters on HTTPRoute create/update/delete; RBAC and the Helm chart version are updated to `0.6.1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06cb07ffaeec01ef04929c1f56d67aa35be5cc24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->