### PR TITLE
Consider method, header, and query specificity in route sorting

### DIFF
--- a/pkg/routes/expand.go
+++ b/pkg/routes/expand.go
@@ -484,9 +484,12 @@ func buildBackendString(refs []v1alpha1.BackendRef, externalNames map[string]str
 // typePriority defines the sort precedence of route types: exact > regex > prefix.
 var typePriority = map[string]int{RouteTypeExact: 0, RouteTypeRegex: 1, RouteTypePrefix: 2}
 
-// SortRoutes sorts routes by priority (descending), then by type, then by path length
+// SortRoutes sorts routes by priority (descending), then by type, then by path
+// length. When those are tied, more specific request match constraints win:
+// method-constrained routes come before unconstrained routes, followed by
+// routes with more header matches and then more query param matches.
 func SortRoutes(routes []Route) {
-	sort.Slice(routes, func(i, j int) bool {
+	sort.SliceStable(routes, func(i, j int) bool {
 		// First by priority descending (higher priority first)
 		if routes[i].Priority != routes[j].Priority {
 			return routes[i].Priority > routes[j].Priority
@@ -499,8 +502,35 @@ func SortRoutes(routes []Route) {
 		}
 
 		// Then by path length descending (longer paths first)
-		return len(routes[i].Path) > len(routes[j].Path)
+		if len(routes[i].Path) != len(routes[j].Path) {
+			return len(routes[i].Path) > len(routes[j].Path)
+		}
+
+		// Then by method specificity: constrained routes before unconstrained routes
+		mi, mj := routeMethodSpecificity(routes[i]), routeMethodSpecificity(routes[j])
+		if mi != mj {
+			return mi > mj
+		}
+
+		// Then by header specificity: more header matches first
+		if len(routes[i].Headers) != len(routes[j].Headers) {
+			return len(routes[i].Headers) > len(routes[j].Headers)
+		}
+
+		// Then by query param specificity: more query param matches first
+		if len(routes[i].QueryParams) != len(routes[j].QueryParams) {
+			return len(routes[i].QueryParams) > len(routes[j].QueryParams)
+		}
+
+		return false
 	})
+}
+
+func routeMethodSpecificity(route Route) int {
+	if route.Method == "" {
+		return 0
+	}
+	return 1
 }
 
 // MergeRoutesConfig merges routes from multiple CustomHTTPRoutes into a single config

--- a/pkg/routes/expand_test.go
+++ b/pkg/routes/expand_test.go
@@ -2011,3 +2011,181 @@ func TestExpandRoutesWithExternalNames(t *testing.T) {
 		t.Errorf("expected backend %q, got %q", expected, routes[0].Backend)
 	}
 }
+
+func TestSortRoutesSpecificityTiebreakers(t *testing.T) {
+	t.Run("method constrained routes sort before unconstrained routes", func(t *testing.T) {
+		routes := []Route{
+			{Path: "/checkout", Type: RouteTypePrefix, Priority: 1000},
+			{Path: "/checkout", Type: RouteTypePrefix, Priority: 1000, Method: "GET"},
+		}
+
+		SortRoutes(routes)
+
+		if routes[0].Method != "GET" {
+			t.Fatalf("expected method-constrained route first, got %+v", routes[0])
+		}
+	})
+
+	t.Run("routes with more header matches sort first", func(t *testing.T) {
+		routes := []Route{
+			{
+				Path:     "/checkout",
+				Type:     RouteTypePrefix,
+				Priority: 1000,
+				Headers: []RouteHeaderMatch{
+					{Name: "force", Value: "staging"},
+				},
+			},
+			{Path: "/checkout", Type: RouteTypePrefix, Priority: 1000},
+		}
+
+		SortRoutes(routes)
+
+		if len(routes[0].Headers) != 1 {
+			t.Fatalf("expected header-constrained route first, got %+v", routes[0])
+		}
+	})
+
+	t.Run("routes with more query param matches sort first", func(t *testing.T) {
+		routes := []Route{
+			{
+				Path:     "/checkout",
+				Type:     RouteTypePrefix,
+				Priority: 1000,
+				QueryParams: []RouteQueryParamMatch{
+					{Name: "env", Value: "staging"},
+				},
+			},
+			{Path: "/checkout", Type: RouteTypePrefix, Priority: 1000},
+		}
+
+		SortRoutes(routes)
+
+		if len(routes[0].QueryParams) != 1 {
+			t.Fatalf("expected query-constrained route first, got %+v", routes[0])
+		}
+	})
+}
+
+func TestFindRoutePrefersMoreSpecificMatches(t *testing.T) {
+	t.Run("header-specific route wins over generic route", func(t *testing.T) {
+		routes := []Route{
+			{
+				Path:     "/checkout",
+				Type:     RouteTypePrefix,
+				Priority: 1000,
+				Backend:  "stable.default.svc.cluster.local:80",
+			},
+			{
+				Path:     "/checkout",
+				Type:     RouteTypePrefix,
+				Priority: 1000,
+				Backend:  "staging.default.svc.cluster.local:80",
+				Headers: []RouteHeaderMatch{
+					{Name: "force", Value: "staging"},
+				},
+			},
+		}
+		SortRoutes(routes)
+
+		loader := &Loader{
+			config: &RoutesConfig{
+				Version: 1,
+				Hosts: map[string][]Route{
+					"example.com": routes,
+				},
+			},
+		}
+
+		route := loader.FindRoute("example.com", RequestMatch{
+			Path:    "/checkout",
+			Headers: map[string]string{"force": "staging"},
+		})
+		if route == nil {
+			t.Fatal("expected matching route")
+		}
+		if route.Backend != "staging.default.svc.cluster.local:80" {
+			t.Fatalf("expected staging backend, got %q", route.Backend)
+		}
+	})
+
+	t.Run("method-specific route wins over generic route", func(t *testing.T) {
+		routes := []Route{
+			{
+				Path:     "/checkout",
+				Type:     RouteTypePrefix,
+				Priority: 1000,
+				Backend:  "stable.default.svc.cluster.local:80",
+			},
+			{
+				Path:     "/checkout",
+				Type:     RouteTypePrefix,
+				Priority: 1000,
+				Backend:  "get.default.svc.cluster.local:80",
+				Method:   "GET",
+			},
+		}
+		SortRoutes(routes)
+
+		loader := &Loader{
+			config: &RoutesConfig{
+				Version: 1,
+				Hosts: map[string][]Route{
+					"example.com": routes,
+				},
+			},
+		}
+
+		route := loader.FindRoute("example.com", RequestMatch{
+			Path:   "/checkout",
+			Method: "GET",
+		})
+		if route == nil {
+			t.Fatal("expected matching route")
+		}
+		if route.Backend != "get.default.svc.cluster.local:80" {
+			t.Fatalf("expected GET backend, got %q", route.Backend)
+		}
+	})
+
+	t.Run("query-specific route wins over generic route", func(t *testing.T) {
+		routes := []Route{
+			{
+				Path:     "/checkout",
+				Type:     RouteTypePrefix,
+				Priority: 1000,
+				Backend:  "stable.default.svc.cluster.local:80",
+			},
+			{
+				Path:     "/checkout",
+				Type:     RouteTypePrefix,
+				Priority: 1000,
+				Backend:  "staging.default.svc.cluster.local:80",
+				QueryParams: []RouteQueryParamMatch{
+					{Name: "env", Value: "staging"},
+				},
+			},
+		}
+		SortRoutes(routes)
+
+		loader := &Loader{
+			config: &RoutesConfig{
+				Version: 1,
+				Hosts: map[string][]Route{
+					"example.com": routes,
+				},
+			},
+		}
+
+		route := loader.FindRoute("example.com", RequestMatch{
+			Path:        "/checkout",
+			QueryParams: map[string]string{"env": "staging"},
+		})
+		if route == nil {
+			t.Fatal("expected matching route")
+		}
+		if route.Backend != "staging.default.svc.cluster.local:80" {
+			t.Fatalf("expected staging backend, got %q", route.Backend)
+		}
+	})
+}

--- a/pkg/routes/expand_test.go
+++ b/pkg/routes/expand_test.go
@@ -2015,8 +2015,8 @@ func TestExpandRoutesWithExternalNames(t *testing.T) {
 func TestSortRoutesSpecificityTiebreakers(t *testing.T) {
 	t.Run("method constrained routes sort before unconstrained routes", func(t *testing.T) {
 		routes := []Route{
-			{Path: "/checkout", Type: RouteTypePrefix, Priority: 1000},
-			{Path: "/checkout", Type: RouteTypePrefix, Priority: 1000, Method: "GET"},
+			{Path: "/example", Type: RouteTypePrefix, Priority: 1000},
+			{Path: "/example", Type: RouteTypePrefix, Priority: 1000, Method: "GET"},
 		}
 
 		SortRoutes(routes)
@@ -2029,14 +2029,14 @@ func TestSortRoutesSpecificityTiebreakers(t *testing.T) {
 	t.Run("routes with more header matches sort first", func(t *testing.T) {
 		routes := []Route{
 			{
-				Path:     "/checkout",
+				Path:     "/example",
 				Type:     RouteTypePrefix,
 				Priority: 1000,
 				Headers: []RouteHeaderMatch{
 					{Name: "force", Value: "staging"},
 				},
 			},
-			{Path: "/checkout", Type: RouteTypePrefix, Priority: 1000},
+			{Path: "/example", Type: RouteTypePrefix, Priority: 1000},
 		}
 
 		SortRoutes(routes)
@@ -2049,14 +2049,14 @@ func TestSortRoutesSpecificityTiebreakers(t *testing.T) {
 	t.Run("routes with more query param matches sort first", func(t *testing.T) {
 		routes := []Route{
 			{
-				Path:     "/checkout",
+				Path:     "/example",
 				Type:     RouteTypePrefix,
 				Priority: 1000,
 				QueryParams: []RouteQueryParamMatch{
 					{Name: "env", Value: "staging"},
 				},
 			},
-			{Path: "/checkout", Type: RouteTypePrefix, Priority: 1000},
+			{Path: "/example", Type: RouteTypePrefix, Priority: 1000},
 		}
 
 		SortRoutes(routes)
@@ -2071,13 +2071,13 @@ func TestFindRoutePrefersMoreSpecificMatches(t *testing.T) {
 	t.Run("header-specific route wins over generic route", func(t *testing.T) {
 		routes := []Route{
 			{
-				Path:     "/checkout",
+				Path:     "/example",
 				Type:     RouteTypePrefix,
 				Priority: 1000,
 				Backend:  "stable.default.svc.cluster.local:80",
 			},
 			{
-				Path:     "/checkout",
+				Path:     "/example",
 				Type:     RouteTypePrefix,
 				Priority: 1000,
 				Backend:  "staging.default.svc.cluster.local:80",
@@ -2098,7 +2098,7 @@ func TestFindRoutePrefersMoreSpecificMatches(t *testing.T) {
 		}
 
 		route := loader.FindRoute("example.com", RequestMatch{
-			Path:    "/checkout",
+			Path:    "/example",
 			Headers: map[string]string{"force": "staging"},
 		})
 		if route == nil {
@@ -2112,13 +2112,13 @@ func TestFindRoutePrefersMoreSpecificMatches(t *testing.T) {
 	t.Run("method-specific route wins over generic route", func(t *testing.T) {
 		routes := []Route{
 			{
-				Path:     "/checkout",
+				Path:     "/example",
 				Type:     RouteTypePrefix,
 				Priority: 1000,
 				Backend:  "stable.default.svc.cluster.local:80",
 			},
 			{
-				Path:     "/checkout",
+				Path:     "/example",
 				Type:     RouteTypePrefix,
 				Priority: 1000,
 				Backend:  "get.default.svc.cluster.local:80",
@@ -2137,7 +2137,7 @@ func TestFindRoutePrefersMoreSpecificMatches(t *testing.T) {
 		}
 
 		route := loader.FindRoute("example.com", RequestMatch{
-			Path:   "/checkout",
+			Path:   "/example",
 			Method: "GET",
 		})
 		if route == nil {
@@ -2151,13 +2151,13 @@ func TestFindRoutePrefersMoreSpecificMatches(t *testing.T) {
 	t.Run("query-specific route wins over generic route", func(t *testing.T) {
 		routes := []Route{
 			{
-				Path:     "/checkout",
+				Path:     "/example",
 				Type:     RouteTypePrefix,
 				Priority: 1000,
 				Backend:  "stable.default.svc.cluster.local:80",
 			},
 			{
-				Path:     "/checkout",
+				Path:     "/example",
 				Type:     RouteTypePrefix,
 				Priority: 1000,
 				Backend:  "staging.default.svc.cluster.local:80",
@@ -2178,7 +2178,7 @@ func TestFindRoutePrefersMoreSpecificMatches(t *testing.T) {
 		}
 
 		route := loader.FindRoute("example.com", RequestMatch{
-			Path:        "/checkout",
+			Path:        "/example",
 			QueryParams: map[string]string{"env": "staging"},
 		})
 		if route == nil {


### PR DESCRIPTION
## Summary
- add method, header, and query parameter specificity tie-breakers to route sorting
- add regression coverage to ensure more specific matches win over generic ones
- keep the new tests generic and free of project-specific paths

Closes #30
