### PR TITLE
fix(chart): grant httproutes RBAC to operator

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: customrouter
 description: A Helm chart for CustomRouter - Kubernetes operator and external processor for dynamic HTTP routing
 type: application
-version: 0.6.3
+version: 0.6.4
 appVersion: "0.6.3"
 kubeVersion: ">= 1.26.0-0"
 keywords:

--- a/chart/templates/operator-rbac.yaml
+++ b/chart/templates/operator-rbac.yaml
@@ -68,7 +68,6 @@ rules:
       - patch
       - update
       - watch
-  {{- if .Values.operator.webhook.enabled }}
   - apiGroups:
       - gateway.networking.k8s.io
     resources:
@@ -77,6 +76,7 @@ rules:
       - get
       - list
       - watch
+  {{- if .Values.operator.webhook.enabled }}
   - apiGroups:
       - admissionregistration.k8s.io
     resources:


### PR DESCRIPTION
## Problem

Default chart installations (`operator.webhook.enabled: false`) deploy the operator without `httproutes.gateway.networking.k8s.io` permissions, so the operator crashloops at startup with:

```
httproutes.gateway.networking.k8s.io is forbidden:
User "system:serviceaccount:customrouter:customrouter-operator"
cannot list resource "httproutes" in API group "gateway.networking.k8s.io"
at the cluster scope
```

This was discovered when deploying the operator in our sandbox cluster (`fc-it-cross-sbx-rev1`) — `CustomHTTPRoute` resources were created but never reconciled, and pods were OOMing-then-failing on cache sync. Production (`fc-front-pro-rev1`) was not affected because the missing rule had been added manually to the `ClusterRole` at some point in the past.

## Root cause

`chart/templates/operator-rbac.yaml` gates two unrelated rules behind the same `{{- if .Values.operator.webhook.enabled }}` block:

- `httproutes` (gateway.networking.k8s.io) — needed **always**
- `validatingwebhookconfigurations` (admissionregistration.k8s.io) — needed **only with the webhook**

The `httproutes` permission is not webhook-specific. Both controllers register `HTTPRoute` watchers unconditionally:

- `internal/controller/customhttproute/controller.go:176` — `Watches(&gatewayv1.HTTPRoute{}, ...)`
- `internal/controller/externalprocessorattachment/controller.go:126` — same

And the kubebuilder markers reflect that:

- `internal/controller/customhttproute/controller.go:57` — `// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes,verbs=get;list;watch`
- `internal/controller/externalprocessorattachment/controller.go:47` — same

The chart template diverged from what `make manifests` would generate (`config/operator/deploy/rbac/role.yaml` lists `httproutes` unconditionally).

## Fix

Move the `httproutes` rule out of the `webhook.enabled` conditional. Keep `validatingwebhookconfigurations` gated since only the webhook actually needs it.

## Verification

```bash
# Default values: now includes httproutes (was missing before)
helm template customrouter chart/ --namespace test \
  | grep -A4 "resources:" | grep -A1 httproutes
#   - apiGroups:
#     - gateway.networking.k8s.io
#   - httproutes

# With webhook enabled: both rules present, no duplicates (8 → 9 rules)
helm template customrouter chart/ --namespace test \
  --set operator.webhook.enabled=true \
  | sed -n '/^kind: ClusterRole$/,/^---$/p' \
  | grep -c "^  - apiGroups:"
# 9
```

## Changes

- `chart/templates/operator-rbac.yaml`: 1 line moved
- `chart/Chart.yaml`: bump `0.6.3` → `0.6.4` (chart-only change, `appVersion` unchanged)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk Helm/RBAC change that only broadens the operator ClusterRole to allow listing/watching `httproutes`; main risk is over-permissioning, but it matches the operator’s actual watch behavior.
> 
> **Overview**
> Fixes default Helm installs where the operator crashloops due to missing Gateway API `HTTPRoute` permissions.
> 
> The chart now grants `gateway.networking.k8s.io/httproutes` `get/list/watch` RBAC **unconditionally**, while keeping `admissionregistration.k8s.io/validatingwebhookconfigurations` permissions **still gated** behind `operator.webhook.enabled`. Also bumps the chart `version` to `0.6.4` (no `appVersion` change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac31a791e212a995aaafa7b68ed0761137091007. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->