### PR TITLE
fix(controller): audit fixes

### DIFF
--- a/internal/controller/customhttproute/catchall.go
+++ b/internal/controller/customhttproute/catchall.go
@@ -35,14 +35,17 @@ import (
 func (r *CustomHTTPRouteReconciler) reconcileCatchAllFromRoutes(
 	ctx context.Context,
 	routeList *v1alpha1.CustomHTTPRouteList,
+	epaList *v1alpha1.ExternalProcessorAttachmentList,
 ) error {
 	logger := log.FromContext(ctx)
 
 	entries := ef.CollectCatchAllEntries(routeList)
 
-	epaList := &v1alpha1.ExternalProcessorAttachmentList{}
-	if err := r.List(ctx, epaList); err != nil {
-		return fmt.Errorf("failed to list ExternalProcessorAttachments: %w", err)
+	if epaList == nil {
+		epaList = &v1alpha1.ExternalProcessorAttachmentList{}
+		if err := r.List(ctx, epaList); err != nil {
+			return fmt.Errorf("failed to list ExternalProcessorAttachments: %w", err)
+		}
 	}
 
 	if len(epaList.Items) == 0 {

--- a/internal/controller/customhttproute/controller.go
+++ b/internal/controller/customhttproute/controller.go
@@ -275,7 +275,7 @@ func (r *CustomHTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	// 3. Check if the resource instance is marked to be deleted
 	if !objectManifest.DeletionTimestamp.IsZero() {
 		if controllerutil.ContainsFinalizer(objectManifest, controller.ResourceFinalizer) {
-			result, err = r.ReconcileObject(ctx, watch.Deleted, objectManifest)
+			result, _, _, err = r.ReconcileObject(ctx, watch.Deleted, objectManifest)
 			if err != nil {
 				logger.Error(err, "Failed to reconcile deletion", "name", req.Name)
 				return result, err
@@ -335,7 +335,7 @@ func (r *CustomHTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}()
 
 	// 7. The resource already exists: manage the update
-	result, err = r.ReconcileObject(ctx, watch.Modified, objectManifest)
+	result, routeList, epaList, err := r.ReconcileObject(ctx, watch.Modified, objectManifest)
 	if err != nil {
 		r.UpdateConditionReconciled(objectManifest)
 		r.UpdateConditionConfigMapFailed(objectManifest, err.Error())
@@ -354,7 +354,7 @@ func (r *CustomHTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	r.UpdateConditionReconciled(objectManifest)
 	r.UpdateConditionConfigMapSynced(objectManifest)
 
-	catchAllStatus, catchAllErr := r.ComputeCatchAllProgrammedStatus(ctx, objectManifest)
+	catchAllStatus, catchAllErr := r.ComputeCatchAllProgrammedStatus(ctx, objectManifest, routeList, epaList)
 	if catchAllErr != nil {
 		logger.Error(catchAllErr, "Failed to compute CatchAllProgrammed status", "name", req.Name)
 	} else {

--- a/internal/controller/customhttproute/controller.go
+++ b/internal/controller/customhttproute/controller.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -47,6 +48,12 @@ const targetRefIndexField = ".spec.targetRef.name"
 // target are enqueued together (typically at controller cache resync).
 const DefaultRebuildCooldown = 2 * time.Second
 
+// DefaultStateGCInterval is the period between sweeps of the in-memory state
+// (lastRebuildAt, partitionHashes). Sweeps drop entries for targets that no
+// longer have any live CustomHTTPRoute, preventing unbounded growth across
+// the controller lifetime when targets are created and deleted repeatedly.
+const DefaultStateGCInterval = 1 * time.Hour
+
 // CustomHTTPRouteReconciler reconciles a CustomHTTPRoute object
 type CustomHTTPRouteReconciler struct {
 	client.Client
@@ -59,6 +66,11 @@ type CustomHTTPRouteReconciler struct {
 	// after the remaining wait instead of repeating the rebuild work.
 	// When zero, DefaultRebuildCooldown is used.
 	RebuildCooldown time.Duration
+
+	// StateGCInterval controls how often the in-memory state GC runs.
+	// When zero, DefaultStateGCInterval is used. A negative value disables
+	// the periodic GC entirely (useful in tests).
+	StateGCInterval time.Duration
 
 	// lastRebuildAt records the last successful rebuild time per target name.
 	// Read/written under rebuildMu.
@@ -123,19 +135,113 @@ func (r *CustomHTTPRouteReconciler) clearTargetState(target string) {
 	delete(r.lastRebuildAt, target)
 	r.rebuildMu.Unlock()
 
-	// Partition names follow the pattern "customrouter-routes-<target>-<index>"
-	// where <index> is a non-negative integer. We must verify that the
-	// character immediately after the prefix is a digit to avoid accidentally
-	// evicting entries for targets that share a hyphenated prefix (e.g.
-	// target "foo" must not match "customrouter-routes-foo-bar-0").
-	prefix := configMapBaseName + "-" + target + "-"
+	// Use parsePartitionName to identify entries that genuinely belong to
+	// this target. Naive prefix matching would incorrectly evict entries
+	// from targets whose name shares a hyphenated prefix (e.g. clearing
+	// "foo" must leave "foo-bar" partitions untouched).
 	r.partitionHashesMu.Lock()
 	for name := range r.partitionHashes {
-		if len(name) > len(prefix) && name[:len(prefix)] == prefix && name[len(prefix)] >= '0' && name[len(prefix)] <= '9' {
+		if owner, _, ok := parsePartitionName(name); ok && owner == target {
 			delete(r.partitionHashes, name)
 		}
 	}
 	r.partitionHashesMu.Unlock()
+}
+
+// effectiveStateGCInterval returns the GC interval. Zero falls back to the
+// default; negative values mean "disabled".
+func (r *CustomHTTPRouteReconciler) effectiveStateGCInterval() time.Duration {
+	if r.StateGCInterval == 0 {
+		return DefaultStateGCInterval
+	}
+	return r.StateGCInterval
+}
+
+// runStateGC is registered as a manager runnable. It sweeps lastRebuildAt and
+// partitionHashes on a fixed interval, dropping entries for targets that no
+// longer have any live CustomHTTPRoute. Without this sweep the maps grow
+// monotonically as targets are created and deleted, since clearTargetState is
+// only invoked on the deletion path of the last route for a target — a path
+// that can be missed if the controller restarts mid-deletion or if entries
+// were created by a now-vanished resource.
+func (r *CustomHTTPRouteReconciler) runStateGC(ctx context.Context) error {
+	interval := r.effectiveStateGCInterval()
+	if interval <= 0 {
+		<-ctx.Done()
+		return nil
+	}
+	logger := log.FromContext(ctx).WithName("state-gc")
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			if err := r.gcStateOnce(ctx); err != nil {
+				logger.Error(err, "state GC sweep failed; will retry next interval")
+			}
+		}
+	}
+}
+
+// gcStateOnce performs a single sweep. Exposed separately so tests can
+// trigger it deterministically without waiting for the ticker.
+func (r *CustomHTTPRouteReconciler) gcStateOnce(ctx context.Context) error {
+	routeList := &crv1alpha1.CustomHTTPRouteList{}
+	if err := r.List(ctx, routeList); err != nil {
+		return fmt.Errorf("list CustomHTTPRoutes for state GC: %w", err)
+	}
+	live := make(map[string]struct{}, len(routeList.Items))
+	for i := range routeList.Items {
+		live[routeList.Items[i].Spec.TargetRef.Name] = struct{}{}
+	}
+
+	logger := log.FromContext(ctx).WithName("state-gc")
+
+	r.rebuildMu.Lock()
+	rebuildEvicted := 0
+	for t := range r.lastRebuildAt {
+		if _, ok := live[t]; !ok {
+			delete(r.lastRebuildAt, t)
+			rebuildEvicted++
+		}
+	}
+	rebuildSize := len(r.lastRebuildAt)
+	r.rebuildMu.Unlock()
+
+	r.partitionHashesMu.Lock()
+	hashesEvicted := 0
+	for name := range r.partitionHashes {
+		owner, _, ok := parsePartitionName(name)
+		if !ok {
+			// Unparseable entries cannot be safely associated with a
+			// live target, but they were inserted by us via
+			// partitionName, so this branch is unreachable in practice;
+			// drop them defensively to avoid permanent leaks if the
+			// naming scheme ever changes.
+			delete(r.partitionHashes, name)
+			hashesEvicted++
+			continue
+		}
+		if _, ok := live[owner]; !ok {
+			delete(r.partitionHashes, name)
+			hashesEvicted++
+		}
+	}
+	hashesSize := len(r.partitionHashes)
+	r.partitionHashesMu.Unlock()
+
+	if rebuildEvicted > 0 || hashesEvicted > 0 {
+		logger.Info("evicted stale in-memory state",
+			"liveTargets", len(live),
+			"rebuildEvicted", rebuildEvicted,
+			"rebuildRemaining", rebuildSize,
+			"hashesEvicted", hashesEvicted,
+			"hashesRemaining", hashesSize,
+		)
+	}
+	return nil
 }
 
 // +kubebuilder:rbac:groups=customrouter.freepik.com,resources=customhttproutes,verbs=get;list;watch;create;update;patch;delete
@@ -275,6 +381,10 @@ func (r *CustomHTTPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	maxConcurrent := r.MaxConcurrentReconciles
 	if maxConcurrent <= 0 {
 		maxConcurrent = 1
+	}
+
+	if err := mgr.Add(manager.RunnableFunc(r.runStateGC)); err != nil {
+		return fmt.Errorf("register state GC runnable: %w", err)
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/customhttproute/controller.go
+++ b/internal/controller/customhttproute/controller.go
@@ -286,7 +286,16 @@ func (r *CustomHTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 				return nil
 			})
 			if err != nil {
-				logger.Error(err, "Failed to remove finalizer", "name", req.Name)
+				// The owning namespace is often deleted before the CR's last
+				// reconcile lands, so the finalizer-removal Update races against
+				// cascading namespace deletion. In that case the apiserver returns
+				// NotFound (either for the CR or for its namespace) and the
+				// resource is already effectively gone — nothing left to clean up.
+				if client.IgnoreNotFound(err) == nil {
+					logger.V(1).Info("Resource or namespace already gone, skipping finalizer removal", "name", req.Name)
+				} else {
+					logger.Error(err, "Failed to remove finalizer", "name", req.Name)
+				}
 			}
 		}
 		return ctrl.Result{}, nil

--- a/internal/controller/customhttproute/controller_test.go
+++ b/internal/controller/customhttproute/controller_test.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2024-2026 Freepik Company S.L.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package customhttproute
+
+import (
+	"context"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"github.com/freepik-company/customrouter/api/v1alpha1"
+	"github.com/freepik-company/customrouter/internal/controller"
+)
+
+// TestReconcile_FinalizerRemoval_NamespaceGone_DoesNotError is a regression
+// test for the production error:
+//
+//	"Failed to remove finalizer" error="namespaces \"…\" not found"
+//
+// When a namespace is cascade-deleted, the apiserver removes its
+// CustomHTTPRoutes alongside it. The controller's final reconcile observes
+// the DeletionTimestamp and tries to strip the finalizer; the Get-then-Update
+// inside UpdateWithRetry then hits a 404 because the namespace (and the CR)
+// are gone. Reconcile must treat that as success rather than logging a
+// scary "Failed to remove finalizer" line and surfacing a workqueue error.
+func TestReconcile_FinalizerRemoval_NamespaceGone_DoesNotError(t *testing.T) {
+	scheme := newScheme()
+
+	now := metav1.Now()
+	route := &v1alpha1.CustomHTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "route-1",
+			Namespace:         "doomed-ns",
+			Finalizers:        []string{controller.ResourceFinalizer},
+			DeletionTimestamp: &now,
+		},
+		Spec: v1alpha1.CustomHTTPRouteSpec{
+			TargetRef: v1alpha1.TargetRef{Name: "gw"},
+		},
+	}
+
+	// Simulate the apiserver response when the owning namespace has been
+	// deleted between the Reconcile Get and the finalizer-removal Update.
+	// UpdateWithRetry does Get-then-Update; intercepting Update is enough to
+	// reach the error-classification block we want to exercise.
+	notFoundOnUpdate := interceptor.Funcs{
+		Update: func(
+			ctx context.Context,
+			c client.WithWatch,
+			obj client.Object,
+			opts ...client.UpdateOption,
+		) error {
+			return apierrors.NewNotFound(
+				schema.GroupResource{Resource: "namespaces"},
+				obj.GetNamespace(),
+			)
+		},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(route).
+		WithIndex(&v1alpha1.CustomHTTPRoute{}, targetRefIndexField, func(obj client.Object) []string {
+			r := obj.(*v1alpha1.CustomHTTPRoute)
+			return []string{r.Spec.TargetRef.Name}
+		}).
+		WithInterceptorFuncs(notFoundOnUpdate).
+		Build()
+
+	r := &CustomHTTPRouteReconciler{
+		Client:             cl,
+		Scheme:             scheme,
+		ConfigMapNamespace: "test-ns",
+		// Disable the in-memory state GC so the test stays self-contained.
+		StateGCInterval: -1,
+	}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: route.Name, Namespace: route.Namespace},
+	})
+
+	if err != nil {
+		t.Fatalf("Reconcile must swallow NotFound from finalizer removal, got error: %v", err)
+	}
+	if res.RequeueAfter != 0 {
+		t.Fatalf("Reconcile must not requeue on swallowed NotFound, got: %+v", res)
+	}
+}
+
+// TestReconcile_FinalizerRemoval_RealErrorIsNotMisclassified guards the
+// inverse direction: the NotFound shortcut must be *narrow*. A Forbidden or
+// any other non-NotFound error must remain observable so real bugs are not
+// hidden behind the "namespace gone" log line.
+func TestReconcile_FinalizerRemoval_RealErrorIsNotMisclassified(t *testing.T) {
+	scheme := newScheme()
+
+	now := metav1.Now()
+	route := &v1alpha1.CustomHTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "route-2",
+			Namespace:         "ns",
+			Finalizers:        []string{controller.ResourceFinalizer},
+			DeletionTimestamp: &now,
+		},
+		Spec: v1alpha1.CustomHTTPRouteSpec{
+			TargetRef: v1alpha1.TargetRef{Name: "gw"},
+		},
+	}
+
+	forbiddenOnUpdate := interceptor.Funcs{
+		Update: func(
+			ctx context.Context,
+			c client.WithWatch,
+			obj client.Object,
+			opts ...client.UpdateOption,
+		) error {
+			return apierrors.NewForbidden(
+				schema.GroupResource{Group: v1alpha1.GroupVersion.Group, Resource: "customhttproutes"},
+				obj.GetName(),
+				nil,
+			)
+		},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(route).
+		WithIndex(&v1alpha1.CustomHTTPRoute{}, targetRefIndexField, func(obj client.Object) []string {
+			r := obj.(*v1alpha1.CustomHTTPRoute)
+			return []string{r.Spec.TargetRef.Name}
+		}).
+		WithInterceptorFuncs(forbiddenOnUpdate).
+		Build()
+
+	r := &CustomHTTPRouteReconciler{
+		Client:             cl,
+		Scheme:             scheme,
+		ConfigMapNamespace: "test-ns",
+		StateGCInterval:    -1,
+	}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: route.Name, Namespace: route.Namespace},
+	})
+	// Current Reconcile contract: finalizer-removal failures are logged but
+	// not returned to the workqueue. What this test pins down is that the
+	// finalizer is *still present* on the object after a non-NotFound error,
+	// proving the shortcut did not silently swallow the real failure.
+	if err != nil {
+		t.Fatalf("current contract: Reconcile logs but does not return finalizer-removal errors; got %v", err)
+	}
+
+	got := &v1alpha1.CustomHTTPRoute{}
+	if err := cl.Get(context.Background(), types.NamespacedName{Name: route.Name, Namespace: route.Namespace}, got); err != nil {
+		t.Fatalf("Get after Reconcile: %v", err)
+	}
+	if len(got.Finalizers) == 0 {
+		t.Fatalf("finalizer should still be present after Forbidden Update, got none")
+	}
+}

--- a/internal/controller/customhttproute/cors.go
+++ b/internal/controller/customhttproute/cors.go
@@ -34,14 +34,17 @@ import (
 func (r *CustomHTTPRouteReconciler) reconcileCORSFromRoutes(
 	ctx context.Context,
 	routeList *v1alpha1.CustomHTTPRouteList,
+	epaList *v1alpha1.ExternalProcessorAttachmentList,
 ) error {
 	logger := log.FromContext(ctx)
 
 	entries := ef.CollectCORSEntries(routeList)
 
-	epaList := &v1alpha1.ExternalProcessorAttachmentList{}
-	if err := r.List(ctx, epaList); err != nil {
-		return fmt.Errorf("failed to list ExternalProcessorAttachments: %w", err)
+	if epaList == nil {
+		epaList = &v1alpha1.ExternalProcessorAttachmentList{}
+		if err := r.List(ctx, epaList); err != nil {
+			return fmt.Errorf("failed to list ExternalProcessorAttachments: %w", err)
+		}
 	}
 
 	if len(epaList.Items) == 0 {

--- a/internal/controller/customhttproute/mirror.go
+++ b/internal/controller/customhttproute/mirror.go
@@ -34,14 +34,17 @@ import (
 func (r *CustomHTTPRouteReconciler) reconcileMirrorFromRoutes(
 	ctx context.Context,
 	routeList *v1alpha1.CustomHTTPRouteList,
+	epaList *v1alpha1.ExternalProcessorAttachmentList,
 ) error {
 	logger := log.FromContext(ctx)
 
 	entries := ef.CollectMirrorEntries(routeList)
 
-	epaList := &v1alpha1.ExternalProcessorAttachmentList{}
-	if err := r.List(ctx, epaList); err != nil {
-		return fmt.Errorf("failed to list ExternalProcessorAttachments: %w", err)
+	if epaList == nil {
+		epaList = &v1alpha1.ExternalProcessorAttachmentList{}
+		if err := r.List(ctx, epaList); err != nil {
+			return fmt.Errorf("failed to list ExternalProcessorAttachments: %w", err)
+		}
 	}
 
 	if len(epaList.Items) == 0 {

--- a/internal/controller/customhttproute/parse_partition_name_test.go
+++ b/internal/controller/customhttproute/parse_partition_name_test.go
@@ -119,11 +119,11 @@ func TestGCStateOnceEvictsDeadTargets(t *testing.T) {
 		"dead":  time.Now(),
 	}
 	r.partitionHashes = map[string]uint32{
-		"customrouter-routes-alive-0":   1,
-		"customrouter-routes-alive-2":   2,
-		"customrouter-routes-dead-0":    3,
-		"customrouter-routes-dead-7":    4,
-		"unparseable-name":              5, // defensive eviction
+		"customrouter-routes-alive-0": 1,
+		"customrouter-routes-alive-2": 2,
+		"customrouter-routes-dead-0":  3,
+		"customrouter-routes-dead-7":  4,
+		"unparseable-name":            5, // defensive eviction
 	}
 	r.rebuildMu = sync.Mutex{}
 	r.partitionHashesMu = sync.Mutex{}

--- a/internal/controller/customhttproute/parse_partition_name_test.go
+++ b/internal/controller/customhttproute/parse_partition_name_test.go
@@ -1,0 +1,161 @@
+package customhttproute
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/freepik-company/customrouter/api/v1alpha1"
+)
+
+func TestParsePartitionName(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantTarget string
+		wantIndex  int
+		wantOK     bool
+	}{
+		{"simple target index 0", "customrouter-routes-foo-0", "foo", 0, true},
+		{"simple target larger index", "customrouter-routes-foo-12", "foo", 12, true},
+		{"hyphenated target", "customrouter-routes-foo-bar-5", "foo-bar", 5, true},
+		{"deeply hyphenated target", "customrouter-routes-a-b-c-d-99", "a-b-c-d", 99, true},
+
+		{"missing prefix", "other-prefix-foo-0", "", 0, false},
+		{"empty target", "customrouter-routes--0", "", 0, false},
+		{"missing index", "customrouter-routes-foo", "", 0, false},
+		{"trailing dash", "customrouter-routes-foo-", "", 0, false},
+		{"non-numeric index", "customrouter-routes-foo-abc", "", 0, false},
+		{"empty string", "", "", 0, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotTarget, gotIndex, gotOK := parsePartitionName(tc.input)
+			if gotOK != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", gotOK, tc.wantOK)
+			}
+			if !tc.wantOK {
+				return
+			}
+			if gotTarget != tc.wantTarget {
+				t.Errorf("target = %q, want %q", gotTarget, tc.wantTarget)
+			}
+			if gotIndex != tc.wantIndex {
+				t.Errorf("index = %d, want %d", gotIndex, tc.wantIndex)
+			}
+		})
+	}
+}
+
+// TestClearTargetStateNoPrefixCollision verifies that clearing target "foo"
+// does not evict cached partition hashes that genuinely belong to a different
+// target whose name happens to share the "foo-" prefix (e.g. "foo-bar").
+// Prior to M-2 the implementation used naive prefix matching which would
+// incorrectly drop neighbour-target entries.
+func TestClearTargetStateNoPrefixCollision(t *testing.T) {
+	r := &CustomHTTPRouteReconciler{
+		rebuildMu:         sync.Mutex{},
+		lastRebuildAt:     map[string]time.Time{"foo": time.Now(), "foo-bar": time.Now()},
+		partitionHashesMu: sync.Mutex{},
+		partitionHashes: map[string]uint32{
+			"customrouter-routes-foo-0":     1,
+			"customrouter-routes-foo-1":     2,
+			"customrouter-routes-foo-bar-0": 3,
+			"customrouter-routes-foo-bar-7": 4,
+			"customrouter-routes-other-0":   5,
+		},
+	}
+
+	r.clearTargetState("foo")
+
+	if _, ok := r.lastRebuildAt["foo"]; ok {
+		t.Errorf("lastRebuildAt[foo] should have been cleared")
+	}
+	if _, ok := r.lastRebuildAt["foo-bar"]; !ok {
+		t.Errorf("lastRebuildAt[foo-bar] should have been preserved")
+	}
+
+	wantPresent := []string{
+		"customrouter-routes-foo-bar-0",
+		"customrouter-routes-foo-bar-7",
+		"customrouter-routes-other-0",
+	}
+	wantAbsent := []string{
+		"customrouter-routes-foo-0",
+		"customrouter-routes-foo-1",
+	}
+	for _, k := range wantPresent {
+		if _, ok := r.partitionHashes[k]; !ok {
+			t.Errorf("partitionHashes[%q] should have been preserved", k)
+		}
+	}
+	for _, k := range wantAbsent {
+		if _, ok := r.partitionHashes[k]; ok {
+			t.Errorf("partitionHashes[%q] should have been cleared", k)
+		}
+	}
+}
+
+// TestGCStateOnceEvictsDeadTargets verifies that the periodic state GC
+// removes lastRebuildAt and partitionHashes entries whose target no longer
+// has any live CustomHTTPRoute, while preserving entries for live targets.
+func TestGCStateOnceEvictsDeadTargets(t *testing.T) {
+	// Only "alive" target has a live CustomHTTPRoute; "dead" target's CR
+	// was already deleted but its in-memory state was leaked.
+	aliveCR := &v1alpha1.CustomHTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "r1", Namespace: "default"},
+		Spec: v1alpha1.CustomHTTPRouteSpec{
+			TargetRef: v1alpha1.TargetRef{Name: "alive"},
+		},
+	}
+	r := newReconciler(runtime.Object(aliveCR))
+	r.lastRebuildAt = map[string]time.Time{
+		"alive": time.Now(),
+		"dead":  time.Now(),
+	}
+	r.partitionHashes = map[string]uint32{
+		"customrouter-routes-alive-0":   1,
+		"customrouter-routes-alive-2":   2,
+		"customrouter-routes-dead-0":    3,
+		"customrouter-routes-dead-7":    4,
+		"unparseable-name":              5, // defensive eviction
+	}
+	r.rebuildMu = sync.Mutex{}
+	r.partitionHashesMu = sync.Mutex{}
+
+	if err := r.gcStateOnce(context.Background()); err != nil {
+		t.Fatalf("gcStateOnce returned error: %v", err)
+	}
+
+	if _, ok := r.lastRebuildAt["alive"]; !ok {
+		t.Errorf("lastRebuildAt[alive] should have been preserved")
+	}
+	if _, ok := r.lastRebuildAt["dead"]; ok {
+		t.Errorf("lastRebuildAt[dead] should have been evicted")
+	}
+
+	wantPresent := []string{
+		"customrouter-routes-alive-0",
+		"customrouter-routes-alive-2",
+	}
+	wantAbsent := []string{
+		"customrouter-routes-dead-0",
+		"customrouter-routes-dead-7",
+		"unparseable-name",
+	}
+	for _, k := range wantPresent {
+		if _, ok := r.partitionHashes[k]; !ok {
+			t.Errorf("partitionHashes[%q] should have been preserved", k)
+		}
+	}
+	for _, k := range wantAbsent {
+		if _, ok := r.partitionHashes[k]; ok {
+			t.Errorf("partitionHashes[%q] should have been evicted", k)
+		}
+	}
+}

--- a/internal/controller/customhttproute/partitioning_bench_test.go
+++ b/internal/controller/customhttproute/partitioning_bench_test.go
@@ -36,7 +36,9 @@ func BenchmarkSplitHostRoutes(b *testing.B) {
 		b.Run(tc.name, func(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
-				_, _, _ = r.splitHostRoutes("default", host, routes, 0)
+				if _, _, err := r.splitHostRoutes("default", host, routes, 0); err != nil {
+					b.Fatalf("splitHostRoutes returned error: %v", err)
+				}
 			}
 		})
 	}

--- a/internal/controller/customhttproute/partitioning_bench_test.go
+++ b/internal/controller/customhttproute/partitioning_bench_test.go
@@ -36,7 +36,7 @@ func BenchmarkSplitHostRoutes(b *testing.B) {
 		b.Run(tc.name, func(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
-				_, _ = r.splitHostRoutes("default", host, routes, 0)
+				_, _, _ = r.splitHostRoutes("default", host, routes, 0)
 			}
 		})
 	}

--- a/internal/controller/customhttproute/partitioning_stability_test.go
+++ b/internal/controller/customhttproute/partitioning_stability_test.go
@@ -72,6 +72,19 @@ func diffPartitions(before, after map[string]string) (changed, added, removed []
 	return
 }
 
+func mustSplitHostRoutes(
+	t *testing.T,
+	r *CustomHTTPRouteReconciler,
+	hostRoutes []routes.Route,
+) ([]ConfigMapPartition, int) {
+	t.Helper()
+	parts, next, err := r.splitHostRoutes("default", testHost, hostRoutes, 0)
+	if err != nil {
+		t.Fatalf("splitHostRoutes returned error: %v", err)
+	}
+	return parts, next
+}
+
 // TestSplitHostRoutes_StableUnderInsertion is the core regression test for the
 // hash-based partitioning. With greedy size-based packing, inserting a single
 // route at an arbitrary position in the input slice cascades every downstream
@@ -79,10 +92,9 @@ func diffPartitions(before, after map[string]string) (changed, added, removed []
 // most one partition.
 func TestSplitHostRoutes_StableUnderInsertion(t *testing.T) {
 	r := &CustomHTTPRouteReconciler{ConfigMapNamespace: "default"}
-	host := testHost
 
 	base := largeRouteSet("base", 600)
-	beforeParts, _, _ := r.splitHostRoutes("default", host, base, 0)
+	beforeParts, _ := mustSplitHostRoutes(t, r, base)
 	if len(beforeParts) < 5 {
 		t.Fatalf("test setup too small: only %d partitions", len(beforeParts))
 	}
@@ -99,7 +111,7 @@ func TestSplitHostRoutes_StableUnderInsertion(t *testing.T) {
 	})
 	withInsert = append(withInsert, base[300:]...)
 
-	afterParts, _, _ := r.splitHostRoutes("default", host, withInsert, 0)
+	afterParts, _ := mustSplitHostRoutes(t, r, withInsert)
 	after := partitionsByName(afterParts)
 
 	changed, added, removed := diffPartitions(before, after)
@@ -114,10 +126,9 @@ func TestSplitHostRoutes_StableUnderInsertion(t *testing.T) {
 // without changing the set of routes produces identical partitions.
 func TestSplitHostRoutes_StableUnderReorder(t *testing.T) {
 	r := &CustomHTTPRouteReconciler{ConfigMapNamespace: "default"}
-	host := testHost
 
 	base := largeRouteSet("base", 600)
-	beforeParts, _, _ := r.splitHostRoutes("default", host, base, 0)
+	beforeParts, _ := mustSplitHostRoutes(t, r, base)
 	before := partitionsByName(beforeParts)
 
 	// Reverse the slice to exercise the "different input order, same set"
@@ -126,7 +137,7 @@ func TestSplitHostRoutes_StableUnderReorder(t *testing.T) {
 	for i := range base {
 		reordered[i] = base[len(base)-1-i]
 	}
-	afterParts, _, _ := r.splitHostRoutes("default", host, reordered, 0)
+	afterParts, _ := mustSplitHostRoutes(t, r, reordered)
 	after := partitionsByName(afterParts)
 
 	changed, added, removed := diffPartitions(before, after)
@@ -141,12 +152,11 @@ func TestSplitHostRoutes_StableUnderReorder(t *testing.T) {
 // content dedup at upsertSingleConfigMap).
 func TestSplitHostRoutes_DeterministicForSameInput(t *testing.T) {
 	r := &CustomHTTPRouteReconciler{ConfigMapNamespace: "default"}
-	host := testHost
 	base := largeRouteSet("base", 200)
 
-	run1Parts, _, _ := r.splitHostRoutes("default", host, base, 0)
+	run1Parts, _ := mustSplitHostRoutes(t, r, base)
 	run1 := partitionsByName(run1Parts)
-	run2Parts, _, _ := r.splitHostRoutes("default", host, base, 0)
+	run2Parts, _ := mustSplitHostRoutes(t, r, base)
 	run2 := partitionsByName(run2Parts)
 
 	if len(run1) != len(run2) {
@@ -169,10 +179,9 @@ func TestSplitHostRoutes_DeterministicForSameInput(t *testing.T) {
 // distribution would have packed too many large routes together.
 func TestSplitHostRoutes_RespectsConfigMapSizeLimit(t *testing.T) {
 	r := &CustomHTTPRouteReconciler{ConfigMapNamespace: "default"}
-	host := testHost
 
 	base := largeRouteSet("base", 1500)
-	parts, _, _ := r.splitHostRoutes("default", host, base, 0)
+	parts, _ := mustSplitHostRoutes(t, r, base)
 
 	for _, p := range parts {
 		if len(p.Data) > maxConfigMapSize {
@@ -184,7 +193,7 @@ func TestSplitHostRoutes_RespectsConfigMapSizeLimit(t *testing.T) {
 // TestSplitHostRoutes_EmptyInput returns no partitions for an empty input.
 func TestSplitHostRoutes_EmptyInput(t *testing.T) {
 	r := &CustomHTTPRouteReconciler{ConfigMapNamespace: "default"}
-	parts, _, _ := r.splitHostRoutes("default", testHost, nil, 0)
+	parts, _ := mustSplitHostRoutes(t, r, nil)
 	if len(parts) != 0 {
 		t.Fatalf("expected 0 partitions for empty input, got %d", len(parts))
 	}
@@ -198,14 +207,13 @@ func TestSplitHostRoutes_EmptyInput(t *testing.T) {
 // not reuse the names reserved here for empty-bucket slots.
 func TestSplitHostRoutes_NextIndexReservesEmptyBuckets(t *testing.T) {
 	r := &CustomHTTPRouteReconciler{ConfigMapNamespace: "default"}
-	host := testHost
 
 	// 600 padded routes push the total well past the 1MB partition limit so
 	// bucketCount lands on a power of two large enough to leave several empty
 	// slots after hashing — exactly the case where the caller must advance
 	// by bucketCount rather than by len(returnedPartitions).
 	base := largeRouteSet("base", 600)
-	parts, next, _ := r.splitHostRoutes("default", host, base, 0)
+	parts, next := mustSplitHostRoutes(t, r, base)
 
 	// The emitted set of partition names must form a strict subset of the
 	// reserved index range, with at least one empty slot to make this test
@@ -289,15 +297,14 @@ func TestRouteBucket_Deterministic(t *testing.T) {
 // across a representative small-growth window.
 func TestStableBucketCount_DoesNotOscillate(t *testing.T) {
 	r := &CustomHTTPRouteReconciler{ConfigMapNamespace: "default"}
-	host := testHost
 
 	base := largeRouteSet("base", 600)
-	beforeParts, _, _ := r.splitHostRoutes("default", host, base, 0)
+	beforeParts, _ := mustSplitHostRoutes(t, r, base)
 	bcBefore := len(beforeParts)
 
 	// Add 5% more routes (well within the 2× headroom).
 	grown := largeRouteSet("base", 630)
-	afterParts, _, _ := r.splitHostRoutes("default", host, grown, 0)
+	afterParts, _ := mustSplitHostRoutes(t, r, grown)
 	bcAfter := len(afterParts)
 
 	if bcAfter != bcBefore {
@@ -343,5 +350,24 @@ func TestRouteBucket_DistinctRoutesDistribute(t *testing.T) {
 	}
 	if len(hits) < buckets/2 {
 		t.Fatalf("hash distribution too narrow: %d buckets hit out of %d", len(hits), buckets)
+	}
+}
+
+func TestSplitHostRoutes_RouteTooLargeReturnsError(t *testing.T) {
+	r := &CustomHTTPRouteReconciler{ConfigMapNamespace: "default"}
+	hostRoutes := []routes.Route{
+		{
+			Type:    routes.RouteTypePrefix,
+			Path:    "/too-big",
+			Backend: strings.Repeat("z", maxConfigMapSize),
+		},
+	}
+
+	_, _, err := r.splitHostRoutes("default", testHost, hostRoutes, 0)
+	if err == nil {
+		t.Fatalf("expected splitHostRoutes to fail for oversized single route")
+	}
+	if !strings.Contains(err.Error(), "exceeds single-partition limit") {
+		t.Fatalf("unexpected error for oversized route: %v", err)
 	}
 }

--- a/internal/controller/customhttproute/partitioning_stability_test.go
+++ b/internal/controller/customhttproute/partitioning_stability_test.go
@@ -82,7 +82,7 @@ func TestSplitHostRoutes_StableUnderInsertion(t *testing.T) {
 	host := testHost
 
 	base := largeRouteSet("base", 600)
-	beforeParts, _ := r.splitHostRoutes("default", host, base, 0)
+	beforeParts, _, _ := r.splitHostRoutes("default", host, base, 0)
 	if len(beforeParts) < 5 {
 		t.Fatalf("test setup too small: only %d partitions", len(beforeParts))
 	}
@@ -99,7 +99,7 @@ func TestSplitHostRoutes_StableUnderInsertion(t *testing.T) {
 	})
 	withInsert = append(withInsert, base[300:]...)
 
-	afterParts, _ := r.splitHostRoutes("default", host, withInsert, 0)
+	afterParts, _, _ := r.splitHostRoutes("default", host, withInsert, 0)
 	after := partitionsByName(afterParts)
 
 	changed, added, removed := diffPartitions(before, after)
@@ -117,7 +117,7 @@ func TestSplitHostRoutes_StableUnderReorder(t *testing.T) {
 	host := testHost
 
 	base := largeRouteSet("base", 600)
-	beforeParts, _ := r.splitHostRoutes("default", host, base, 0)
+	beforeParts, _, _ := r.splitHostRoutes("default", host, base, 0)
 	before := partitionsByName(beforeParts)
 
 	// Reverse the slice to exercise the "different input order, same set"
@@ -126,7 +126,7 @@ func TestSplitHostRoutes_StableUnderReorder(t *testing.T) {
 	for i := range base {
 		reordered[i] = base[len(base)-1-i]
 	}
-	afterParts, _ := r.splitHostRoutes("default", host, reordered, 0)
+	afterParts, _, _ := r.splitHostRoutes("default", host, reordered, 0)
 	after := partitionsByName(afterParts)
 
 	changed, added, removed := diffPartitions(before, after)
@@ -144,9 +144,9 @@ func TestSplitHostRoutes_DeterministicForSameInput(t *testing.T) {
 	host := testHost
 	base := largeRouteSet("base", 200)
 
-	run1Parts, _ := r.splitHostRoutes("default", host, base, 0)
+	run1Parts, _, _ := r.splitHostRoutes("default", host, base, 0)
 	run1 := partitionsByName(run1Parts)
-	run2Parts, _ := r.splitHostRoutes("default", host, base, 0)
+	run2Parts, _, _ := r.splitHostRoutes("default", host, base, 0)
 	run2 := partitionsByName(run2Parts)
 
 	if len(run1) != len(run2) {
@@ -172,7 +172,7 @@ func TestSplitHostRoutes_RespectsConfigMapSizeLimit(t *testing.T) {
 	host := testHost
 
 	base := largeRouteSet("base", 1500)
-	parts, _ := r.splitHostRoutes("default", host, base, 0)
+	parts, _, _ := r.splitHostRoutes("default", host, base, 0)
 
 	for _, p := range parts {
 		if len(p.Data) > maxConfigMapSize {
@@ -184,7 +184,7 @@ func TestSplitHostRoutes_RespectsConfigMapSizeLimit(t *testing.T) {
 // TestSplitHostRoutes_EmptyInput returns no partitions for an empty input.
 func TestSplitHostRoutes_EmptyInput(t *testing.T) {
 	r := &CustomHTTPRouteReconciler{ConfigMapNamespace: "default"}
-	parts, _ := r.splitHostRoutes("default", testHost, nil, 0)
+	parts, _, _ := r.splitHostRoutes("default", testHost, nil, 0)
 	if len(parts) != 0 {
 		t.Fatalf("expected 0 partitions for empty input, got %d", len(parts))
 	}
@@ -205,7 +205,7 @@ func TestSplitHostRoutes_NextIndexReservesEmptyBuckets(t *testing.T) {
 	// slots after hashing — exactly the case where the caller must advance
 	// by bucketCount rather than by len(returnedPartitions).
 	base := largeRouteSet("base", 600)
-	parts, next := r.splitHostRoutes("default", host, base, 0)
+	parts, next, _ := r.splitHostRoutes("default", host, base, 0)
 
 	// The emitted set of partition names must form a strict subset of the
 	// reserved index range, with at least one empty slot to make this test
@@ -242,7 +242,10 @@ func TestSplitByHosts_MultipleHostsNoCollision(t *testing.T) {
 			"b.example.com": largeRouteSet("b", 200),
 		},
 	}
-	parts := r.splitByHosts("default", config)
+	parts, err := r.splitByHosts("default", config)
+	if err != nil {
+		t.Fatalf("splitByHosts returned error: %v", err)
+	}
 
 	seen := make(map[string]struct{}, len(parts))
 	for _, p := range parts {
@@ -289,12 +292,12 @@ func TestStableBucketCount_DoesNotOscillate(t *testing.T) {
 	host := testHost
 
 	base := largeRouteSet("base", 600)
-	beforeParts, _ := r.splitHostRoutes("default", host, base, 0)
+	beforeParts, _, _ := r.splitHostRoutes("default", host, base, 0)
 	bcBefore := len(beforeParts)
 
 	// Add 5% more routes (well within the 2× headroom).
 	grown := largeRouteSet("base", 630)
-	afterParts, _ := r.splitHostRoutes("default", host, grown, 0)
+	afterParts, _, _ := r.splitHostRoutes("default", host, grown, 0)
 	bcAfter := len(afterParts)
 
 	if bcAfter != bcBefore {

--- a/internal/controller/customhttproute/status.go
+++ b/internal/controller/customhttproute/status.go
@@ -104,19 +104,25 @@ func (r *CustomHTTPRouteReconciler) UpdateConditionCatchAllProgrammed(
 func (r *CustomHTTPRouteReconciler) ComputeCatchAllProgrammedStatus(
 	ctx context.Context,
 	route *v1alpha1.CustomHTTPRoute,
+	routeList *v1alpha1.CustomHTTPRouteList,
+	epaList *v1alpha1.ExternalProcessorAttachmentList,
 ) (ef.CatchAllProgrammedStatus, error) {
 	if route.Spec.CatchAllRoute == nil {
 		return ef.CatchAllProgrammedStatus{Reason: controller.ConditionReasonCatchAllNotConfigured}, nil
 	}
 
-	routeList := &v1alpha1.CustomHTTPRouteList{}
-	if err := r.List(ctx, routeList); err != nil {
-		return ef.CatchAllProgrammedStatus{}, fmt.Errorf("failed to list CustomHTTPRoutes: %w", err)
+	if routeList == nil {
+		routeList = &v1alpha1.CustomHTTPRouteList{}
+		if err := r.List(ctx, routeList); err != nil {
+			return ef.CatchAllProgrammedStatus{}, fmt.Errorf("failed to list CustomHTTPRoutes: %w", err)
+		}
 	}
 
-	epaList := &v1alpha1.ExternalProcessorAttachmentList{}
-	if err := r.List(ctx, epaList); err != nil {
-		return ef.CatchAllProgrammedStatus{}, fmt.Errorf("failed to list ExternalProcessorAttachments: %w", err)
+	if epaList == nil {
+		epaList = &v1alpha1.ExternalProcessorAttachmentList{}
+		if err := r.List(ctx, epaList); err != nil {
+			return ef.CatchAllProgrammedStatus{}, fmt.Errorf("failed to list ExternalProcessorAttachments: %w", err)
+		}
 	}
 
 	return ef.EvaluateCatchAllProgrammed(route, routeList, epaList), nil

--- a/internal/controller/customhttproute/sync.go
+++ b/internal/controller/customhttproute/sync.go
@@ -91,7 +91,7 @@ func (r *CustomHTTPRouteReconciler) ReconcileObject(
 	ctx context.Context,
 	eventType watch.EventType,
 	resourceManifest *v1alpha1.CustomHTTPRoute,
-) (ctrl.Result, error) {
+) (ctrl.Result, *v1alpha1.CustomHTTPRouteList, *v1alpha1.ExternalProcessorAttachmentList, error) {
 	logger := log.FromContext(ctx)
 	target := resourceManifest.Spec.TargetRef.Name
 
@@ -116,7 +116,7 @@ func (r *CustomHTTPRouteReconciler) ReconcileObject(
 			logger.V(1).Info("target rebuild in cooldown, requeueing",
 				"target", target,
 				"wait", remaining.String())
-			return ctrl.Result{RequeueAfter: remaining}, nil
+			return ctrl.Result{RequeueAfter: remaining}, nil, nil, nil
 		}
 	}
 
@@ -135,14 +135,14 @@ func (r *CustomHTTPRouteReconciler) ReconcileObject(
 			"previousTarget", previousTarget,
 			"newTarget", target)
 		if err := r.rebuildConfigMapsForTarget(ctx, previousTarget); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to rebuild ConfigMaps for previous target %s: %w", previousTarget, err)
+			return ctrl.Result{}, nil, nil, fmt.Errorf("failed to rebuild ConfigMaps for previous target %s: %w", previousTarget, err)
 		}
 		r.markRebuilt(previousTarget, time.Now())
 	}
 
 	// Rebuild ConfigMaps for the current target
 	if err := r.rebuildConfigMapsForTarget(ctx, target); err != nil {
-		return ctrl.Result{}, err
+		return ctrl.Result{}, nil, nil, err
 	}
 	r.markRebuilt(target, time.Now())
 
@@ -160,29 +160,32 @@ func (r *CustomHTTPRouteReconciler) ReconcileObject(
 	needMirror := hasMirror || eventType == watch.Deleted || hadMirror
 	needCORS := hasCORS || eventType == watch.Deleted || hadCORS
 
+	var routeList *v1alpha1.CustomHTTPRouteList
+	var epaList *v1alpha1.ExternalProcessorAttachmentList
+
 	if needCatchAll || needMirror || needCORS {
-		routeList := &v1alpha1.CustomHTTPRouteList{}
+		routeList = &v1alpha1.CustomHTTPRouteList{}
 		if err := r.List(ctx, routeList); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to list CustomHTTPRoutes for envoyfilter reconciliation: %w", err)
+			return ctrl.Result{}, nil, nil, fmt.Errorf("failed to list CustomHTTPRoutes for envoyfilter reconciliation: %w", err)
 		}
-		epaList := &v1alpha1.ExternalProcessorAttachmentList{}
+		epaList = &v1alpha1.ExternalProcessorAttachmentList{}
 		if err := r.List(ctx, epaList); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to list ExternalProcessorAttachments for envoyfilter reconciliation: %w", err)
+			return ctrl.Result{}, nil, nil, fmt.Errorf("failed to list ExternalProcessorAttachments for envoyfilter reconciliation: %w", err)
 		}
 
 		if needCatchAll {
 			if err := r.reconcileCatchAllFromRoutes(ctx, routeList, epaList); err != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to reconcile catch-all routes: %w", err)
+				return ctrl.Result{}, nil, nil, fmt.Errorf("failed to reconcile catch-all routes: %w", err)
 			}
 		}
 		if needMirror {
 			if err := r.reconcileMirrorFromRoutes(ctx, routeList, epaList); err != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to reconcile mirror routes: %w", err)
+				return ctrl.Result{}, nil, nil, fmt.Errorf("failed to reconcile mirror routes: %w", err)
 			}
 		}
 		if needCORS {
 			if err := r.reconcileCORSFromRoutes(ctx, routeList, epaList); err != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to reconcile cors routes: %w", err)
+				return ctrl.Result{}, nil, nil, fmt.Errorf("failed to reconcile cors routes: %w", err)
 			}
 		}
 	}
@@ -193,11 +196,11 @@ func (r *CustomHTTPRouteReconciler) ReconcileObject(
 	// additional reconcile cycles per route change.
 	if eventType != watch.Deleted {
 		if err := r.ensureAnnotations(ctx, resourceManifest, target, hasCatchAll, hasMirror, hasCORS); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to update tracking annotations: %w", err)
+			return ctrl.Result{}, nil, nil, fmt.Errorf("failed to update tracking annotations: %w", err)
 		}
 	}
 
-	return ctrl.Result{}, nil
+	return ctrl.Result{}, routeList, epaList, nil
 }
 
 // routeHasCORSAction returns true if any rule in the route declares a cors action.
@@ -631,7 +634,17 @@ func (r *CustomHTTPRouteReconciler) splitHostRoutes(
 		if !overflow {
 			break
 		}
-		bucketCount *= 2
+		if attempt < maxRetries-1 {
+			bucketCount *= 2
+		}
+	}
+	if overflow {
+		return nil, startIndex, fmt.Errorf(
+			"unable to partition host %s within size limit after %d retries (bucketCount=%d)",
+			host,
+			maxRetries,
+			bucketCount,
+		)
 	}
 
 	// Sort each bucket so the JSON output is byte-stable across reconciles.

--- a/internal/controller/customhttproute/sync.go
+++ b/internal/controller/customhttproute/sync.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -145,28 +146,44 @@ func (r *CustomHTTPRouteReconciler) ReconcileObject(
 	}
 	r.markRebuilt(target, time.Now())
 
-	// Reconcile catch-all EnvoyFilter when:
-	// - the route currently has catchAllRoute configured
-	// - the route is being deleted (may have had catch-all entries)
-	// - the route previously had catchAllRoute but it was removed (annotation present, field nil)
+	// Reconcile catch-all / mirror / CORS EnvoyFilters when any axis is
+	// active or was previously active for this route. To avoid listing
+	// CustomHTTPRoutes and ExternalProcessorAttachments three separate
+	// times (once per axis), list them once here and pass them into each
+	// reconciler. On a controller resync against a large catalogue this
+	// removes 4 redundant API/cache reads (2 axes × 2 list types) per
+	// reconcile, on top of the writes already saved by the cooldown.
 	hasCatchAll := resourceManifest.Spec.CatchAllRoute != nil
-	if hasCatchAll || eventType == watch.Deleted || hadCatchAll {
-		if err := r.reconcileCatchAllFromAllRoutes(ctx); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to reconcile catch-all routes: %w", err)
-		}
-	}
-
 	hasMirror := routeHasMirrorAction(resourceManifest)
-	if hasMirror || eventType == watch.Deleted || hadMirror {
-		if err := r.reconcileMirrorFromAllRoutes(ctx); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to reconcile mirror routes: %w", err)
-		}
-	}
-
 	hasCORS := routeHasCORSAction(resourceManifest)
-	if hasCORS || eventType == watch.Deleted || hadCORS {
-		if err := r.reconcileCORSFromAllRoutes(ctx); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to reconcile cors routes: %w", err)
+	needCatchAll := hasCatchAll || eventType == watch.Deleted || hadCatchAll
+	needMirror := hasMirror || eventType == watch.Deleted || hadMirror
+	needCORS := hasCORS || eventType == watch.Deleted || hadCORS
+
+	if needCatchAll || needMirror || needCORS {
+		routeList := &v1alpha1.CustomHTTPRouteList{}
+		if err := r.List(ctx, routeList); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to list CustomHTTPRoutes for envoyfilter reconciliation: %w", err)
+		}
+		epaList := &v1alpha1.ExternalProcessorAttachmentList{}
+		if err := r.List(ctx, epaList); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to list ExternalProcessorAttachments for envoyfilter reconciliation: %w", err)
+		}
+
+		if needCatchAll {
+			if err := r.reconcileCatchAllFromRoutes(ctx, routeList, epaList); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to reconcile catch-all routes: %w", err)
+			}
+		}
+		if needMirror {
+			if err := r.reconcileMirrorFromRoutes(ctx, routeList, epaList); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to reconcile mirror routes: %w", err)
+			}
+		}
+		if needCORS {
+			if err := r.reconcileCORSFromRoutes(ctx, routeList, epaList); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to reconcile cors routes: %w", err)
+			}
 		}
 	}
 
@@ -195,16 +212,6 @@ func routeHasCORSAction(cr *v1alpha1.CustomHTTPRoute) bool {
 	return false
 }
 
-// reconcileCORSFromAllRoutes lists all routes and drives the per-EPA CORS
-// EnvoyFilter reconciliation.
-func (r *CustomHTTPRouteReconciler) reconcileCORSFromAllRoutes(ctx context.Context) error {
-	routeList := &v1alpha1.CustomHTTPRouteList{}
-	if err := r.List(ctx, routeList); err != nil {
-		return fmt.Errorf("failed to list CustomHTTPRoutes for cors reconciliation: %w", err)
-	}
-	return r.reconcileCORSFromRoutes(ctx, routeList)
-}
-
 // routeHasMirrorAction returns true if any rule in the route declares a
 // request-mirror action. Kept package-local for use in the reconcile trigger.
 func routeHasMirrorAction(cr *v1alpha1.CustomHTTPRoute) bool {
@@ -216,16 +223,6 @@ func routeHasMirrorAction(cr *v1alpha1.CustomHTTPRoute) bool {
 		}
 	}
 	return false
-}
-
-// reconcileMirrorFromAllRoutes lists all routes and drives the per-EPA mirror
-// EnvoyFilter reconciliation.
-func (r *CustomHTTPRouteReconciler) reconcileMirrorFromAllRoutes(ctx context.Context) error {
-	routeList := &v1alpha1.CustomHTTPRouteList{}
-	if err := r.List(ctx, routeList); err != nil {
-		return fmt.Errorf("failed to list CustomHTTPRoutes for mirror reconciliation: %w", err)
-	}
-	return r.reconcileMirrorFromRoutes(ctx, routeList)
 }
 
 // ensureAnnotations batch-updates all tracking annotations (last-target,
@@ -285,16 +282,6 @@ func setBoolAnnotation(ann map[string]string, key string, value bool) {
 	}
 }
 
-// reconcileCatchAllFromAllRoutes lists all routes and reconciles catch-all EnvoyFilters.
-// This is only called when a route with catchAllRoute is modified or any route is deleted.
-func (r *CustomHTTPRouteReconciler) reconcileCatchAllFromAllRoutes(ctx context.Context) error {
-	routeList := &v1alpha1.CustomHTTPRouteList{}
-	if err := r.List(ctx, routeList); err != nil {
-		return fmt.Errorf("failed to list CustomHTTPRoutes for catch-all reconciliation: %w", err)
-	}
-	return r.reconcileCatchAllFromRoutes(ctx, routeList)
-}
-
 // rebuildConfigMapsForTarget rebuilds ConfigMaps only for a specific target
 func (r *CustomHTTPRouteReconciler) rebuildConfigMapsForTarget(ctx context.Context, target string) error {
 	logger := log.FromContext(ctx)
@@ -341,7 +328,10 @@ func (r *CustomHTTPRouteReconciler) rebuildConfigMapsForTarget(ctx context.Conte
 		config := routes.MergeRoutesConfig(allRoutes...)
 
 		// Partition the config into multiple ConfigMaps if needed
-		partitions := r.partitionConfig(target, config)
+		partitions, err := r.partitionConfig(target, config)
+		if err != nil {
+			return fmt.Errorf("failed to partition routes for target %s: %w", target, err)
+		}
 
 		// Create or update the ConfigMaps for this target
 		if err := r.upsertConfigMaps(ctx, partitions); err != nil {
@@ -408,9 +398,12 @@ func (r *CustomHTTPRouteReconciler) resolveExternalNames(
 func (r *CustomHTTPRouteReconciler) partitionConfig(
 	target string,
 	config *routes.RoutesConfig,
-) []ConfigMapPartition {
+) ([]ConfigMapPartition, error) {
 	// Try single partition first
-	data, _ := config.ToJSON()
+	data, err := config.ToJSON()
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize routes for target %s: %w", target, err)
+	}
 	if len(data) <= maxConfigMapSize {
 		return []ConfigMapPartition{
 			{
@@ -418,7 +411,7 @@ func (r *CustomHTTPRouteReconciler) partitionConfig(
 				Target: target,
 				Data:   string(data),
 			},
-		}
+		}, nil
 	}
 
 	// Need to split by hosts
@@ -436,7 +429,7 @@ type ConfigMapPartition struct {
 func (r *CustomHTTPRouteReconciler) splitByHosts(
 	target string,
 	config *routes.RoutesConfig,
-) []ConfigMapPartition {
+) ([]ConfigMapPartition, error) {
 	var partitions []ConfigMapPartition
 
 	// Sort hosts for deterministic ordering
@@ -461,14 +454,20 @@ func (r *CustomHTTPRouteReconciler) splitByHosts(
 			Version: config.Version,
 			Hosts:   map[string][]routes.Route{host: hostRoutes},
 		}
-		hostData, _ := hostConfig.ToJSON()
+		hostData, err := hostConfig.ToJSON()
+		if err != nil {
+			return nil, fmt.Errorf("failed to serialize host %s: %w", host, err)
+		}
 		hostSize := len(hostData)
 
 		// If single host exceeds limit, we need to split the host's routes
 		if hostSize > maxConfigMapSize {
 			// Flush current partition if not empty
 			if len(currentPartition.Hosts) > 0 {
-				partData, _ := currentPartition.ToJSON()
+				partData, err := currentPartition.ToJSON()
+				if err != nil {
+					return nil, fmt.Errorf("failed to serialize partition %d: %w", partIndex, err)
+				}
 				partitions = append(partitions, ConfigMapPartition{
 					Name:   r.partitionName(target, partIndex),
 					Target: target,
@@ -483,7 +482,10 @@ func (r *CustomHTTPRouteReconciler) splitByHosts(
 			}
 
 			// Split this host's routes across multiple partitions
-			hostPartitions, nextIndex := r.splitHostRoutes(target, host, hostRoutes, partIndex)
+			hostPartitions, nextIndex, err := r.splitHostRoutes(target, host, hostRoutes, partIndex)
+			if err != nil {
+				return nil, err
+			}
 			partitions = append(partitions, hostPartitions...)
 			partIndex = nextIndex
 			continue
@@ -492,7 +494,10 @@ func (r *CustomHTTPRouteReconciler) splitByHosts(
 		// Check if adding this host would exceed the limit
 		if currentSize+hostSize > maxConfigMapSize && len(currentPartition.Hosts) > 0 {
 			// Flush current partition
-			partData, _ := currentPartition.ToJSON()
+			partData, err := currentPartition.ToJSON()
+			if err != nil {
+				return nil, fmt.Errorf("failed to serialize partition %d: %w", partIndex, err)
+			}
 			partitions = append(partitions, ConfigMapPartition{
 				Name:   r.partitionName(target, partIndex),
 				Target: target,
@@ -515,7 +520,10 @@ func (r *CustomHTTPRouteReconciler) splitByHosts(
 
 	// Flush remaining partition
 	if len(currentPartition.Hosts) > 0 {
-		partData, _ := currentPartition.ToJSON()
+		partData, err := currentPartition.ToJSON()
+		if err != nil {
+			return nil, fmt.Errorf("failed to serialize final partition %d: %w", partIndex, err)
+		}
 		partitions = append(partitions, ConfigMapPartition{
 			Name:   r.partitionName(target, partIndex),
 			Target: target,
@@ -523,7 +531,7 @@ func (r *CustomHTTPRouteReconciler) splitByHosts(
 		})
 	}
 
-	return partitions
+	return partitions, nil
 }
 
 // splitHostRoutes splits a single host's routes across multiple partitions.
@@ -552,9 +560,9 @@ func (r *CustomHTTPRouteReconciler) splitHostRoutes(
 	host string,
 	hostRoutes []routes.Route,
 	startIndex int,
-) ([]ConfigMapPartition, int) {
+) ([]ConfigMapPartition, int, error) {
 	if len(hostRoutes) == 0 {
-		return nil, startIndex
+		return nil, startIndex, nil
 	}
 
 	// Estimate the total payload and the minimum number of buckets needed so
@@ -575,7 +583,10 @@ func (r *CustomHTTPRouteReconciler) splitHostRoutes(
 	routeSizes := make([]int, len(hostRoutes))
 	totalSize := 0
 	for i, route := range hostRoutes {
-		routeData, _ := json.Marshal(route)
+		routeData, err := json.Marshal(route)
+		if err != nil {
+			return nil, startIndex, fmt.Errorf("failed to serialize route %d for host %s: %w", i, host, err)
+		}
 		routeSizes[i] = len(routeData) + 1 // +1 for comma
 		totalSize += routeSizes[i]
 	}
@@ -622,7 +633,9 @@ func (r *CustomHTTPRouteReconciler) splitHostRoutes(
 		if len(buckets[i]) <= 1 {
 			continue
 		}
-		sortRoutesByIdentity(buckets[i])
+		if err := sortRoutesByIdentity(buckets[i]); err != nil {
+			return nil, startIndex, fmt.Errorf("failed to sort routes for host %s: %w", host, err)
+		}
 	}
 
 	partitions := make([]ConfigMapPartition, 0, bucketCount)
@@ -638,14 +651,17 @@ func (r *CustomHTTPRouteReconciler) splitHostRoutes(
 			Version: 1,
 			Hosts:   map[string][]routes.Route{host: bucket},
 		}
-		partData, _ := partConfig.ToJSON()
+		partData, err := partConfig.ToJSON()
+		if err != nil {
+			return nil, startIndex, fmt.Errorf("failed to serialize bucket %d for host %s: %w", bucketIdx, host, err)
+		}
 		partitions = append(partitions, ConfigMapPartition{
 			Name:   r.partitionName(target, startIndex+bucketIdx),
 			Target: target,
 			Data:   string(partData),
 		})
 	}
-	return partitions, startIndex + bucketCount
+	return partitions, startIndex + bucketCount, nil
 }
 
 // stableBucketCount rounds the minimum required bucket count up to the next
@@ -673,18 +689,22 @@ func stableBucketCount(minBuckets int) int {
 // even when SortRoutes would tie on its real-routing-priority comparisons.
 // Used only inside splitHostRoutes; routing priority is re-established by
 // the extproc loader after merge.
-func sortRoutesByIdentity(rs []routes.Route) {
+func sortRoutesByIdentity(rs []routes.Route) error {
 	// Pre-compute identity keys once (O(n)) so the sort comparator does not
 	// re-marshal routes on every comparison (which would be O(n log n)
 	// allocations in the worst case, creating significant GC pressure for
 	// large buckets).
 	keys := make([]string, len(rs))
 	for i := range rs {
-		k, _ := json.Marshal(rs[i])
+		k, err := json.Marshal(rs[i])
+		if err != nil {
+			return fmt.Errorf("failed to compute identity key for route %d: %w", i, err)
+		}
 		keys[i] = string(k)
 	}
 
 	sort.Stable(routesByIdentity{routes: rs, keys: keys})
+	return nil
 }
 
 // routesByIdentity implements sort.Interface, keeping the pre-computed
@@ -759,6 +779,30 @@ func (r *CustomHTTPRouteReconciler) partitionName(target string, index int) stri
 	return fmt.Sprintf("%s-%s-%d", configMapBaseName, target, index)
 }
 
+// parsePartitionName parses a ConfigMap name produced by partitionName and
+// returns the embedded target name. The boolean is true when the name matches
+// the expected pattern "customrouter-routes-<target>-<index>" with <index> a
+// non-negative decimal integer. Used to evict per-target cache entries
+// without prefix-matching pitfalls (e.g. target "foo" must not match a
+// partition belonging to "foo-bar").
+func parsePartitionName(name string) (target string, index int, ok bool) {
+	prefix := configMapBaseName + "-"
+	if !strings.HasPrefix(name, prefix) {
+		return "", 0, false
+	}
+	rest := name[len(prefix):]
+	dash := strings.LastIndexByte(rest, '-')
+	if dash <= 0 || dash == len(rest)-1 {
+		return "", 0, false
+	}
+	idxStr := rest[dash+1:]
+	idx, err := strconv.Atoi(idxStr)
+	if err != nil || idx < 0 {
+		return "", 0, false
+	}
+	return rest[:dash], idx, true
+}
+
 // upsertConfigMaps creates or updates all ConfigMap partitions for a target
 func (r *CustomHTTPRouteReconciler) upsertConfigMaps(
 	ctx context.Context,
@@ -799,9 +843,8 @@ func (r *CustomHTTPRouteReconciler) upsertSingleConfigMap(
 	}
 
 	partNumber := "0"
-	parts := strings.Split(partition.Name, "-")
-	if len(parts) > 0 {
-		partNumber = parts[len(parts)-1]
+	if _, idx, ok := parsePartitionName(partition.Name); ok {
+		partNumber = strconv.Itoa(idx)
 	}
 
 	configMapLabels := map[string]string{

--- a/internal/controller/customhttproute/sync.go
+++ b/internal/controller/customhttproute/sync.go
@@ -588,6 +588,16 @@ func (r *CustomHTTPRouteReconciler) splitHostRoutes(
 			return nil, startIndex, fmt.Errorf("failed to serialize route %d for host %s: %w", i, host, err)
 		}
 		routeSizes[i] = len(routeData) + 1 // +1 for comma
+		if routeSizes[i]+baseSize > maxConfigMapSize {
+			return nil, startIndex, fmt.Errorf(
+				"route %d for host %s exceeds single-partition limit: routeBytes=%d baseOverhead=%d max=%d",
+				i,
+				host,
+				routeSizes[i],
+				baseSize,
+				maxConfigMapSize,
+			)
+		}
 		totalSize += routeSizes[i]
 	}
 
@@ -599,13 +609,15 @@ func (r *CustomHTTPRouteReconciler) splitHostRoutes(
 
 	// Try to assign with the current bucket count; if any bucket ends up
 	// above maxConfigMapSize, double and try again. Capped to avoid runaway
-	// growth on pathological inputs.
+	// growth on pathological inputs; if still overflowing after all retries,
+	// return an explicit error.
 	var buckets [][]routes.Route
 	const maxRetries = 4
+	overflow := false
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		buckets = make([][]routes.Route, bucketCount)
 		bucketBytes := make([]int, bucketCount)
-		overflow := false
+		overflow = false
 
 		for i, route := range hostRoutes {
 			idx := int(routeBucket(host, route, uint32(bucketCount)))

--- a/internal/controller/customhttproute/sync_test.go
+++ b/internal/controller/customhttproute/sync_test.go
@@ -89,7 +89,10 @@ func TestPartitionConfig_SinglePartition(t *testing.T) {
 		},
 	}
 
-	partitions := r.partitionConfig("default", config)
+	partitions, err := r.partitionConfig("default", config)
+	if err != nil {
+		t.Fatalf("partitionConfig returned error: %v", err)
+	}
 	if len(partitions) != 1 {
 		t.Fatalf("expected 1 partition, got %d", len(partitions))
 	}

--- a/internal/controller/envoyfilter/envoyfilter.go
+++ b/internal/controller/envoyfilter/envoyfilter.go
@@ -272,7 +272,7 @@ func orderedRoutesWithCatchAll(routeList *v1alpha1.CustomHTTPRouteList) []*v1alp
 		}
 		out = append(out, route)
 	}
-	sort.Slice(out, func(i, j int) bool {
+	sort.SliceStable(out, func(i, j int) bool {
 		return routeKey(out[i]) < routeKey(out[j])
 	})
 	return out
@@ -573,7 +573,7 @@ func sortedEntries(m map[string]v1alpha1.BackendRef) []CatchAllEntry {
 	for hostname, ref := range m {
 		entries = append(entries, CatchAllEntry{Hostname: hostname, BackendRef: ref})
 	}
-	sort.Slice(entries, func(i, j int) bool {
+	sort.SliceStable(entries, func(i, j int) bool {
 		return entries[i].Hostname < entries[j].Hostname
 	})
 	return entries

--- a/internal/controller/externalprocessorattachment/controller.go
+++ b/internal/controller/externalprocessorattachment/controller.go
@@ -76,7 +76,15 @@ func (r *ExternalProcessorAttachmentReconciler) Reconcile(ctx context.Context, r
 			patch := client.MergeFrom(attachment.DeepCopy())
 			controllerutil.RemoveFinalizer(attachment, controller.ResourceFinalizer)
 			if err = r.Patch(ctx, attachment, patch); err != nil {
-				logger.Error(err, "Failed to remove finalizer", "name", req.Name)
+				// The owning namespace is often deleted before the CR's last
+				// reconcile lands, so the finalizer-removal Patch races against
+				// cascading namespace deletion. In that case the apiserver returns
+				// NotFound and the resource is already effectively gone.
+				if client.IgnoreNotFound(err) == nil {
+					logger.V(1).Info("Resource or namespace already gone, skipping finalizer removal", "name", req.Name)
+				} else {
+					logger.Error(err, "Failed to remove finalizer", "name", req.Name)
+				}
 			}
 		}
 		return ctrl.Result{}, nil

--- a/internal/controller/externalprocessorattachment/controller_test.go
+++ b/internal/controller/externalprocessorattachment/controller_test.go
@@ -85,7 +85,7 @@ func TestReconcile_FinalizerRemoval_NamespaceGone_DoesNotError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Reconcile must swallow NotFound from finalizer removal, got error: %v", err)
 	}
-	if res.Requeue || res.RequeueAfter != 0 {
+	if res.RequeueAfter != 0 {
 		t.Fatalf("Reconcile must not requeue on swallowed NotFound, got: %+v", res)
 	}
 }

--- a/internal/controller/externalprocessorattachment/controller_test.go
+++ b/internal/controller/externalprocessorattachment/controller_test.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2024-2026 Freepik Company S.L.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package externalprocessorattachment
+
+import (
+	"context"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	crv1alpha1 "github.com/freepik-company/customrouter/api/v1alpha1"
+	"github.com/freepik-company/customrouter/internal/controller"
+)
+
+// TestReconcile_FinalizerRemoval_NamespaceGone_DoesNotError is a regression
+// test for the production log line:
+//
+//	"Failed to remove finalizer" error="namespaces \"…\" not found"
+//
+// When the owning namespace is cascade-deleted, the apiserver returns
+// NotFound on the final Patch that strips the finalizer. The resource is
+// already gone, so Reconcile must treat that as success and not log an error
+// or surface the failure to the controller-runtime workqueue.
+func TestReconcile_FinalizerRemoval_NamespaceGone_DoesNotError(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := crv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+
+	now := metav1.Now()
+	attachment := &crv1alpha1.ExternalProcessorAttachment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "epa-1",
+			Namespace:         "doomed-ns",
+			Finalizers:        []string{controller.ResourceFinalizer},
+			DeletionTimestamp: &now,
+		},
+	}
+
+	notFoundOnPatch := interceptor.Funcs{
+		Patch: func(
+			ctx context.Context,
+			c client.WithWatch,
+			obj client.Object,
+			patch client.Patch,
+			opts ...client.PatchOption,
+		) error {
+			// Simulate the apiserver response when the owning namespace has
+			// been deleted between the Reconcile Get and the finalizer Patch.
+			return apierrors.NewNotFound(
+				schema.GroupResource{Resource: "namespaces"},
+				obj.GetNamespace(),
+			)
+		},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(attachment).
+		WithInterceptorFuncs(notFoundOnPatch).
+		Build()
+
+	r := &ExternalProcessorAttachmentReconciler{Client: cl, Scheme: scheme}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: attachment.Name, Namespace: attachment.Namespace},
+	})
+
+	if err != nil {
+		t.Fatalf("Reconcile must swallow NotFound from finalizer removal, got error: %v", err)
+	}
+	if res.Requeue || res.RequeueAfter != 0 {
+		t.Fatalf("Reconcile must not requeue on swallowed NotFound, got: %+v", res)
+	}
+}
+
+// TestReconcile_FinalizerRemoval_RealErrorIsSurfaced ensures the NotFound
+// shortcut does not also hide unrelated Patch failures, which would mask
+// real bugs.
+func TestReconcile_FinalizerRemoval_RealErrorIsSurfaced(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := crv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+
+	now := metav1.Now()
+	attachment := &crv1alpha1.ExternalProcessorAttachment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "epa-2",
+			Namespace:         "ns",
+			Finalizers:        []string{controller.ResourceFinalizer},
+			DeletionTimestamp: &now,
+		},
+	}
+
+	forbiddenOnPatch := interceptor.Funcs{
+		Patch: func(
+			ctx context.Context,
+			c client.WithWatch,
+			obj client.Object,
+			patch client.Patch,
+			opts ...client.PatchOption,
+		) error {
+			return apierrors.NewForbidden(
+				schema.GroupResource{Group: crv1alpha1.GroupVersion.Group, Resource: "externalprocessorattachments"},
+				obj.GetName(),
+				nil,
+			)
+		},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(attachment).
+		WithInterceptorFuncs(forbiddenOnPatch).
+		Build()
+
+	r := &ExternalProcessorAttachmentReconciler{Client: cl, Scheme: scheme}
+
+	// Reconcile currently does not return the finalizer-removal error (it just
+	// logs it and returns nil). What we assert here is that the NotFound
+	// shortcut is *narrow*: a Forbidden error must NOT be reclassified as
+	// "resource already gone". If a future refactor decides to surface this
+	// error, the assertion below will need adjusting — but the important
+	// regression is that NotFound and Forbidden are not collapsed together.
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: attachment.Name, Namespace: attachment.Namespace},
+	})
+	if err != nil {
+		t.Fatalf("current behavior: Reconcile swallows finalizer-removal errors; got %v", err)
+	}
+
+	// And the resource must still carry the finalizer (proof that the Patch
+	// did not silently succeed).
+	got := &crv1alpha1.ExternalProcessorAttachment{}
+	if err := cl.Get(context.Background(), types.NamespacedName{Name: attachment.Name, Namespace: attachment.Namespace}, got); err != nil {
+		t.Fatalf("Get after Reconcile: %v", err)
+	}
+	if len(got.Finalizers) == 0 {
+		t.Fatalf("finalizer should still be present after Forbidden Patch, got none")
+	}
+}

--- a/internal/webhook/hostname_checker.go
+++ b/internal/webhook/hostname_checker.go
@@ -291,7 +291,7 @@ func convertCustomHeaderMatches(in []customrouterv1alpha1.HeaderMatch) []headerM
 			IsRegex: h.Type == customrouterv1alpha1.HeaderMatchTypeRegularExpression,
 		})
 	}
-	sort.Slice(out, func(i, j int) bool {
+	sort.SliceStable(out, func(i, j int) bool {
 		return strings.ToLower(out[i].Name) < strings.ToLower(out[j].Name)
 	})
 	return out
@@ -329,7 +329,7 @@ func convertCustomQueryParamMatches(in []customrouterv1alpha1.QueryParamMatch) [
 			IsRegex: q.Type == customrouterv1alpha1.QueryParamMatchTypeRegularExpression,
 		})
 	}
-	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 	return out
 }
 
@@ -432,7 +432,7 @@ func extractHTTPRouteMatches(hr *gatewayv1.HTTPRoute) []routeMatch {
 					IsRegex: h.Type != nil && *h.Type == gatewayv1.HeaderMatchRegularExpression,
 				})
 			}
-			sort.Slice(rm.Headers, func(i, j int) bool {
+			sort.SliceStable(rm.Headers, func(i, j int) bool {
 				return strings.ToLower(rm.Headers[i].Name) < strings.ToLower(rm.Headers[j].Name)
 			})
 			for _, q := range m.QueryParams {
@@ -442,7 +442,7 @@ func extractHTTPRouteMatches(hr *gatewayv1.HTTPRoute) []routeMatch {
 					IsRegex: q.Type != nil && *q.Type == gatewayv1.QueryParamMatchRegularExpression,
 				})
 			}
-			sort.Slice(rm.QueryParams, func(i, j int) bool {
+			sort.SliceStable(rm.QueryParams, func(i, j int) bool {
 				return strings.ToLower(rm.QueryParams[i].Name) < strings.ToLower(rm.QueryParams[j].Name)
 			})
 			matches = append(matches, rm)

--- a/pkg/routes/k8s_loader.go
+++ b/pkg/routes/k8s_loader.go
@@ -116,8 +116,11 @@ func (l *K8sLoader) buildConfig() (*RoutesConfig, error) {
 		return nil, fmt.Errorf("failed to list ConfigMaps: %w", err)
 	}
 
-	// Sort by name for deterministic ordering
-	sort.Slice(configMaps.Items, func(i, j int) bool {
+	// Sort by name for deterministic ordering. sort.Stable preserves the
+	// input order for equal keys; with unique ConfigMap names this matches
+	// sort.Slice, but the explicit guarantee is preferable here because the
+	// merged routes feed downstream byte-identical comparisons.
+	sort.SliceStable(configMaps.Items, func(i, j int) bool {
 		return configMaps.Items[i].Name < configMaps.Items[j].Name
 	})
 

--- a/pkg/routes/types.go
+++ b/pkg/routes/types.go
@@ -222,13 +222,18 @@ func (rc *RoutesConfig) ToJSON() ([]byte, error) {
 	buf := acquireJSONBuffer()
 	defer releaseJSONBuffer(buf)
 
+	// Use the default encoder settings (HTML escaping ON) so the output is
+	// byte-identical to the previous json.Marshal-based implementation. The
+	// partitionHashes dedup in the controller depends on this stability:
+	// changing the escaping rules would force a one-time rewrite of every
+	// managed ConfigMap whose routes contain '&', '<' or '>' (e.g. query
+	// strings), defeating the etcd-pressure reduction this pool exists for.
 	enc := json.NewEncoder(buf)
-	enc.SetEscapeHTML(false)
 	if err := enc.Encode(rc); err != nil {
 		return nil, err
 	}
-	// json.Encoder.Encode appends a trailing newline; strip it to keep the
-	// output byte-identical to the previous json.Marshal-based implementation.
+	// json.Encoder.Encode appends a trailing newline; strip it to match
+	// json.Marshal's output exactly.
 	out := buf.Bytes()
 	if n := len(out); n > 0 && out[n-1] == '\n' {
 		out = out[:n-1]

--- a/pkg/routes/types.go
+++ b/pkg/routes/types.go
@@ -19,9 +19,11 @@ limitations under the License.
 package routes
 
 import (
+	"bytes"
 	"encoding/json"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/freepik-company/customrouter/api/v1alpha1"
 )
@@ -188,10 +190,54 @@ func ParseJSON(data []byte) (*RoutesConfig, error) {
 	return &config, nil
 }
 
+// jsonBufferPool reuses bytes.Buffer instances across ToJSON / MarshalRoute
+// invocations. ConfigMap partitioning calls ToJSON many times per reconcile
+// (one per host plus one per bucket), so a pool measurably cuts allocator
+// and GC pressure on large route sets.
+var jsonBufferPool = sync.Pool{
+	New: func() any { return new(bytes.Buffer) },
+}
+
+// jsonMaxRetainedSize bounds the buffer size that gets returned to the pool.
+// Buffers above this threshold are dropped so a single very large reconcile
+// does not pin oversized buffers indefinitely.
+const jsonMaxRetainedSize = 1 << 20 // 1 MiB
+
+func acquireJSONBuffer() *bytes.Buffer {
+	buf := jsonBufferPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	return buf
+}
+
+func releaseJSONBuffer(buf *bytes.Buffer) {
+	if buf.Cap() > jsonMaxRetainedSize {
+		return
+	}
+	jsonBufferPool.Put(buf)
+}
+
 // ToJSON serializes the routes config to compact JSON (no indentation)
 // to minimize ConfigMap size and ensure accurate size calculations
 func (rc *RoutesConfig) ToJSON() ([]byte, error) {
-	return json.Marshal(rc)
+	buf := acquireJSONBuffer()
+	defer releaseJSONBuffer(buf)
+
+	enc := json.NewEncoder(buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(rc); err != nil {
+		return nil, err
+	}
+	// json.Encoder.Encode appends a trailing newline; strip it to keep the
+	// output byte-identical to the previous json.Marshal-based implementation.
+	out := buf.Bytes()
+	if n := len(out); n > 0 && out[n-1] == '\n' {
+		out = out[:n-1]
+	}
+	// Copy out of the pooled buffer because we are about to return the
+	// buffer to the pool; callers may retain the slice arbitrarily.
+	copied := make([]byte, len(out))
+	copy(copied, out)
+	return copied, nil
 }
 
 // CompileRegexes compiles all regex patterns in the routes config (both path

--- a/pkg/routes/types_test.go
+++ b/pkg/routes/types_test.go
@@ -1,6 +1,8 @@
 package routes
 
 import (
+	"bytes"
+	"encoding/json"
 	"testing"
 )
 
@@ -361,5 +363,50 @@ func TestRouteMatchMethod(t *testing.T) {
 					tt.req, tt.route.Method, got, tt.wantMatch)
 			}
 		})
+	}
+}
+
+// TestToJSON_StableBytesAcrossSpecialChars is a tripwire for the
+// partitionHashes dedup in the controller: ToJSON must emit bytes that are
+// identical to a plain json.Marshal call, in particular for routes whose
+// Path / headers / query params contain '&', '<' or '>'. Switching the
+// underlying encoder to SetEscapeHTML(false) (or any other formatting tweak)
+// would silently invalidate every cached partition hash on the next reconcile
+// after an upgrade and force a one-time mass rewrite of managed ConfigMaps.
+func TestToJSON_StableBytesAcrossSpecialChars(t *testing.T) {
+	rc := &RoutesConfig{Hosts: map[string][]Route{
+		"x": {{Path: "/api?a=1&b=2&c=<x>", Type: RouteTypePrefix, Backend: "svc&backend"}},
+	}}
+
+	got, err := rc.ToJSON()
+	if err != nil {
+		t.Fatalf("ToJSON returned error: %v", err)
+	}
+
+	want, err := json.Marshal(rc)
+	if err != nil {
+		t.Fatalf("json.Marshal returned error: %v", err)
+	}
+
+	if !bytes.Equal(got, want) {
+		t.Fatalf("ToJSON output drifted from json.Marshal:\n got: %s\nwant: %s", got, want)
+	}
+
+	// Belt-and-suspenders: lock in the actual escaping behaviour rather than
+	// just byte-equality, so any future change to either side is caught.
+	for _, esc := range []string{`\u0026`, `\u003c`, `\u003e`} {
+		if !bytes.Contains(got, []byte(esc)) {
+			t.Errorf("ToJSON output missing expected escape %q: %s", esc, got)
+		}
+	}
+
+	// Two consecutive invocations must produce identical bytes; protects
+	// against pooled-buffer leakage corrupting the second call.
+	got2, err := rc.ToJSON()
+	if err != nil {
+		t.Fatalf("second ToJSON returned error: %v", err)
+	}
+	if !bytes.Equal(got, got2) {
+		t.Fatalf("ToJSON not deterministic across calls:\nfirst:  %s\nsecond: %s", got, got2)
 	}
 }


### PR DESCRIPTION
— Propagar errores de serialización JSON
  partitionConfig, splitByHosts, splitHostRoutes y sortRoutesByIdentity
  ahora retornan error y el wrap de json.Marshal/ToJSON sube hasta
  ReconcileObject en lugar de descartarse silenciosamente.

— GC periódico de mapas internos del reconciler
  Nuevo runnable runStateGC + gcStateOnce (registrado vía mgr.Add) que
  evicta entradas de lastRebuildAt y partitionHashes cuyo target ya no
  tiene CustomHTTPRoute viva. Intervalo configurable via StateGCInterval
  (default 1h, valor negativo lo deshabilita).

— Parser estructurado de nombres de partición
  parsePartitionName(name) devuelve (target,index,ok) usando
  LastIndexByte+Atoi en vez de prefix matching ingenuo. clearTargetState
  reescrito para iterar partitionHashes y comparar el target parseado,
  evitando colisiones tipo 'foo' vs 'foo-bar'. Tests añadidos para el
  parser y para el invariante de no-colisión.

— Una sola List de routes+EPAs por reconcile
  ReconcileObject lista CustomHTTPRouteList y
  ExternalProcessorAttachmentList una vez y los pasa a las tres
  reconcile{CatchAll,CORS,Mirror}FromRoutes, eliminando hasta 4 List
  redundantes por reconcile. Las funciones reciben epaList opcional
  (nil → listan internamente, para compatibilidad con otras rutas).

— sort.Stable en hot paths con dedup por hash
  Reemplazos en pkg/routes/k8s_loader.go,
  internal/controller/envoyfilter/envoyfilter.go (2x) y
  internal/webhook/hostname_checker.go (4x) para evitar diffs espurios
  en material que después se hashea para etcd writes.

— sync.Pool para serialización JSON
  RoutesConfig.ToJSON() usa un pool de bytes.Buffer + json.NewEncoder
  con SetEscapeHTML(false), reduciendo presión de GC en particionado de
  ConfigMaps con N hosts × M particiones. Buffers grandes (>1MiB) se
  descartan para no retener memoria.

— Verificado: el código ya prefiere h.Value y sólo cae a
  string(h.RawValue) cuando está vacío; no hay margen adicional.

Tests: parse_partition_name_test.go añade cobertura para parsePartitionName, clearTargetState (no colisión por prefijo) y gcStateOnce (evicta dead targets, preserva live).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Kubernetes controller reconciliation, in-memory caching, and ConfigMap partitioning paths; behavior changes could affect update frequency and error surface area in production. Changes are well-scoped and backed by new regression tests, but run periodically via manager and alter failure handling.
> 
> **Overview**
> Reduces controller churn and improves determinism by **reusing a single `List` of routes/EPAs per reconcile** for catch-all/mirror/CORS EnvoyFilter generation, and by switching several ordering points to `sort.SliceStable` to avoid spurious hash/byte diffs.
> 
> Hardens route ConfigMap partitioning by **propagating JSON/serialization and sorting errors** up through `partitionConfig`/`splitByHosts`/`splitHostRoutes`, adding explicit failure cases for oversized routes and hash-bucket overflow, and introducing `parsePartitionName` to avoid target prefix collisions in cache eviction.
> 
> Adds operational robustness: a **periodic in-memory state GC** (`runStateGC`/`gcStateOnce`, configurable via `StateGCInterval`) prevents unbounded growth of `lastRebuildAt`/`partitionHashes`, finalizer removal now treats `NotFound` (namespace gone) as non-actionable in both controllers, and `RoutesConfig.ToJSON` now uses a pooled buffer while preserving byte-identical output (guarded by new tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b4c826ae40d08a8291bd2c4cc64c4626dbbf574. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->