### PR TITLE
feat(extproc): índice de rutas particionado por cabecera (opt-in, sbx)

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -216,6 +216,12 @@ externalProcessors:
       - --target-name=default
       - --routes-configmap-namespace=default
       - --access-log=true
+      # Header-based route partitioning. When one extproc serves many isolated
+      # route sets keyed by a header (e.g. sandbox/preview environments tagged
+      # with "env"), this indexes routes by that header so a request is matched
+      # only against routes sharing its value instead of scanning every route
+      # for the host. Leave unset/empty to keep the default full-scan behavior.
+      # - --route-partition-header=env
       - --grpc-max-recv-msg-size=4194304
       - --grpc-max-send-msg-size=4194304
       - --grpc-max-concurrent-streams=1000

--- a/cmd/extproc/main.go
+++ b/cmd/extproc/main.go
@@ -48,6 +48,10 @@ func main() {
 	flag.BoolVar(&config.AccessLogEnabled, "access-log", config.AccessLogEnabled, "Enable access logging")
 	flag.StringVar(&config.RoutesNamespace, "routes-configmap-namespace", config.RoutesNamespace,
 		"Namespace to read route ConfigMaps from (empty = all namespaces)")
+	flag.StringVar(&config.RoutePartitionHeader, "route-partition-header", config.RoutePartitionHeader,
+		"Request header used to index/partition routes for faster lookup "+
+			"(empty = disabled, full scan). Set e.g. to 'env' in sandbox environments "+
+			"where one extproc serves many route sets keyed by that header.")
 	flag.StringVar(&config.MetricsAddr, "metrics-addr", config.MetricsAddr,
 		"Address to expose Prometheus metrics on (empty to disable)")
 

--- a/internal/extproc/config.go
+++ b/internal/extproc/config.go
@@ -73,6 +73,15 @@ type ServerConfig struct {
 	// MetricsAddr is the address to expose Prometheus metrics on (e.g. ":9090").
 	// Empty string disables the metrics endpoint.
 	MetricsAddr string
+
+	// RoutePartitionHeader, when non-empty, enables a header-based fast-path
+	// index for route lookup: requests carrying this header are matched only
+	// against the routes that share its value, instead of scanning every route
+	// for the host. Intended for environments where a single extproc serves many
+	// isolated route sets disambiguated by a header (e.g. sandbox/preview envs
+	// keyed by "env"). Empty (default) keeps the full-scan behavior, so it is a
+	// no-op unless explicitly set.
+	RoutePartitionHeader string
 }
 
 // DefaultServerConfig returns a ServerConfig with production-ready defaults

--- a/internal/extproc/server.go
+++ b/internal/extproc/server.go
@@ -57,8 +57,9 @@ func NewServer(config *ServerConfig, logger *zap.Logger) (*Server, error) {
 	}
 
 	loader := routes.NewK8sLoader(config.K8sClient, routes.K8sLoaderConfig{
-		TargetName: config.TargetName,
-		Namespace:  config.RoutesNamespace,
+		TargetName:      config.TargetName,
+		Namespace:       config.RoutesNamespace,
+		PartitionHeader: config.RoutePartitionHeader,
 	})
 
 	// Initial load
@@ -128,6 +129,7 @@ func (s *Server) Start(ctx context.Context) error {
 		zap.String("addr", s.config.Addr),
 		zap.String("target_name", s.config.TargetName),
 		zap.String("routes_namespace", s.config.RoutesNamespace),
+		zap.String("route_partition_header", s.config.RoutePartitionHeader),
 		zap.Int("max_recv_msg_size", s.config.MaxRecvMsgSize),
 		zap.Int("max_send_msg_size", s.config.MaxSendMsgSize),
 		zap.Uint32("max_concurrent_streams", s.config.MaxConcurrentStreams),

--- a/pkg/routes/k8s_loader.go
+++ b/pkg/routes/k8s_loader.go
@@ -45,9 +45,10 @@ const (
 
 // K8sLoader loads and watches route configurations from Kubernetes ConfigMaps
 type K8sLoader struct {
-	client     kubernetes.Interface
-	targetName string
-	namespace  string
+	client          kubernetes.Interface
+	targetName      string
+	namespace       string
+	partitionHeader string
 
 	config   *RoutesConfig
 	mu       sync.RWMutex
@@ -66,15 +67,21 @@ type K8sLoaderConfig struct {
 	// Namespace restricts ConfigMap loading to a specific namespace.
 	// Empty string means all namespaces (backward compatible).
 	Namespace string
+
+	// PartitionHeader, when non-empty, enables the header-based fast-path index
+	// in FindRoute (see RoutesConfig.BuildPartitionIndex). Empty disables it,
+	// leaving the historical full-scan behavior untouched.
+	PartitionHeader string
 }
 
 // NewK8sLoader creates a new Kubernetes ConfigMap loader
 func NewK8sLoader(client kubernetes.Interface, config K8sLoaderConfig) *K8sLoader {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &K8sLoader{
-		client:     client,
-		targetName: config.TargetName,
-		namespace:  config.Namespace,
+		client:          client,
+		targetName:      config.TargetName,
+		namespace:       config.Namespace,
+		partitionHeader: config.PartitionHeader,
 		config: &RoutesConfig{
 			Version: 1,
 			Hosts:   make(map[string][]Route),
@@ -161,6 +168,9 @@ func (l *K8sLoader) buildConfig() (*RoutesConfig, error) {
 		return nil, fmt.Errorf("failed to compile regexes: %w", err)
 	}
 
+	// Build the header-based fast-path index (no-op when partitionHeader is empty).
+	mergedConfig.BuildPartitionIndex(l.partitionHeader)
+
 	return mergedConfig, nil
 }
 
@@ -181,19 +191,7 @@ func (l *K8sLoader) FindRoute(host string, req RequestMatch) *Route {
 		host = host[:idx]
 	}
 
-	routes, ok := l.config.Hosts[host]
-	if !ok {
-		return nil
-	}
-
-	// Routes are already sorted by priority, so first match wins
-	for i := range routes {
-		if routes[i].Match(req) {
-			return &routes[i]
-		}
-	}
-
-	return nil
+	return l.config.FindRoute(host, req)
 }
 
 // Watch starts watching ConfigMaps for changes

--- a/pkg/routes/loader.go
+++ b/pkg/routes/loader.go
@@ -34,6 +34,10 @@ type Loader struct {
 	mu        sync.RWMutex
 	watcher   *fsnotify.Watcher
 	onChange  func(*RoutesConfig)
+
+	// PartitionHeader, when non-empty, enables the header-based fast-path index
+	// in FindRoute (see RoutesConfig.BuildPartitionIndex). Set it before Load.
+	PartitionHeader string
 }
 
 // NewLoader creates a new routes loader
@@ -106,6 +110,9 @@ func (l *Loader) Load() error {
 		return fmt.Errorf("failed to compile regexes: %w", err)
 	}
 
+	// Build the header-based fast-path index (no-op when PartitionHeader is empty).
+	mergedConfig.BuildPartitionIndex(l.PartitionHeader)
+
 	l.config = mergedConfig
 	return nil
 }
@@ -127,19 +134,7 @@ func (l *Loader) FindRoute(host string, req RequestMatch) *Route {
 		host = host[:idx]
 	}
 
-	routes, ok := l.config.Hosts[host]
-	if !ok {
-		return nil
-	}
-
-	// Routes are already sorted by priority, so first match wins
-	for i := range routes {
-		if routes[i].Match(req) {
-			return &routes[i]
-		}
-	}
-
-	return nil
+	return l.config.FindRoute(host, req)
 }
 
 // Watch starts watching the routes directory for changes

--- a/pkg/routes/partition_test.go
+++ b/pkg/routes/partition_test.go
@@ -1,0 +1,276 @@
+/*
+Copyright 2024-2026 Freepik Company S.L.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package routes
+
+import (
+	"fmt"
+	"testing"
+)
+
+// envHeader builds a single exact env header matcher.
+func envHeader(value string) []RouteHeaderMatch {
+	return []RouteHeaderMatch{{Name: "env", Value: value, Type: HeaderMatchExact}}
+}
+
+// fullScan replicates the historical lookup so tests can assert the partition
+// index returns byte-for-byte identical results.
+func fullScan(hostRoutes []Route, req RequestMatch) *Route {
+	for i := range hostRoutes {
+		if hostRoutes[i].Match(req) {
+			return &hostRoutes[i]
+		}
+	}
+	return nil
+}
+
+func TestRoutePartitionValue(t *testing.T) {
+	tests := []struct {
+		name   string
+		route  Route
+		want   string
+		wantOK bool
+	}{
+		{
+			name:   "single exact env header is partitionable",
+			route:  Route{Headers: envHeader("sbx-a")},
+			want:   "sbx-a",
+			wantOK: true,
+		},
+		{
+			name:   "no env header is unpartitioned",
+			route:  Route{Headers: []RouteHeaderMatch{{Name: "x-other", Value: "v"}}},
+			want:   "",
+			wantOK: false,
+		},
+		{
+			name:   "empty type defaults to exact and is partitionable",
+			route:  Route{Headers: []RouteHeaderMatch{{Name: "env", Value: "sbx-b"}}},
+			want:   "sbx-b",
+			wantOK: true,
+		},
+		{
+			name:   "regex env header is unpartitioned",
+			route:  Route{Headers: []RouteHeaderMatch{{Name: "env", Value: "sbx-.*", Type: HeaderMatchRegex}}},
+			want:   "",
+			wantOK: false,
+		},
+		{
+			name:   "header name match is case-insensitive",
+			route:  Route{Headers: []RouteHeaderMatch{{Name: "Env", Value: "sbx-c"}}},
+			want:   "sbx-c",
+			wantOK: true,
+		},
+		{
+			name:   "multiple env headers are unpartitioned",
+			route:  Route{Headers: []RouteHeaderMatch{{Name: "env", Value: "a"}, {Name: "env", Value: "b"}}},
+			want:   "",
+			wantOK: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := routePartitionValue(&tt.route, "env")
+			if got != tt.want || ok != tt.wantOK {
+				t.Fatalf("routePartitionValue = (%q, %v), want (%q, %v)", got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+}
+
+// buildSandboxConfig creates a config mirroring the sbx topology: several
+// sandboxes share a host, each route gated by an "env" header, plus a couple of
+// env-agnostic routes to exercise the unpartitioned-merge path.
+func buildSandboxConfig(t *testing.T, withPartition bool) *RoutesConfig {
+	t.Helper()
+	host := "magnific.com"
+	var hostRoutes []Route
+	for _, env := range []string{"sbx-a", "sbx-b", "sbx-c"} {
+		hostRoutes = append(hostRoutes,
+			Route{Path: "/images", Type: RouteTypeExact, Backend: env + "-images", Priority: 1000, Headers: envHeader(env)},
+			Route{Path: "/static", Type: RouteTypePrefix, Backend: env + "-static", Priority: 1000, Headers: envHeader(env)},
+			Route{Path: "/", Type: RouteTypePrefix, Backend: env + "-catchall", Priority: 1, Headers: envHeader(env)},
+		)
+	}
+	// Env-agnostic routes (no env header): must be considered for every value.
+	hostRoutes = append(hostRoutes,
+		Route{Path: "/healthz", Type: RouteTypeExact, Backend: "shared-health", Priority: 5000},
+		Route{Path: "/shared", Type: RouteTypePrefix, Backend: "shared-prefix", Priority: 2000},
+	)
+
+	cfg := &RoutesConfig{Version: 1, Hosts: map[string][]Route{host: hostRoutes}}
+	SortRoutes(cfg.Hosts[host])
+	if err := cfg.CompileRegexes(); err != nil {
+		t.Fatalf("CompileRegexes: %v", err)
+	}
+	if withPartition {
+		cfg.BuildPartitionIndex("env")
+	}
+	return cfg
+}
+
+func TestFindRoutePartitionEquivalence(t *testing.T) {
+	host := "magnific.com"
+	full := buildSandboxConfig(t, false)
+	part := buildSandboxConfig(t, true)
+
+	paths := []string{"/images", "/static/app.js", "/anything/deep/path", "/healthz", "/shared/x", "/"}
+	envs := []string{"sbx-a", "sbx-b", "sbx-c", "sbx-unknown", ""}
+	methods := []string{"GET", "POST"}
+
+	for _, env := range envs {
+		for _, path := range paths {
+			for _, method := range methods {
+				headers := map[string]string{}
+				if env != "" {
+					headers["env"] = env
+				}
+				req := RequestMatch{Path: path, Method: method, Headers: headers}
+
+				want := fullScan(full.Hosts[host], req)
+				gotFull := full.FindRoute(host, req)
+				gotPart := part.FindRoute(host, req)
+
+				if !sameRoute(gotFull, want) {
+					t.Fatalf("baseline FindRoute diverged from full scan for env=%q path=%q: got %s want %s",
+						env, path, backendOf(gotFull), backendOf(want))
+				}
+				if !sameRoute(gotPart, want) {
+					t.Fatalf("partitioned FindRoute diverged for env=%q path=%q method=%q: got %s want %s",
+						env, path, method, backendOf(gotPart), backendOf(want))
+				}
+			}
+		}
+	}
+}
+
+// TestFindRoutePartitionRandomizedEquivalence fuzzes a larger interleaved route
+// set to make sure the index never changes which route wins.
+func TestFindRoutePartitionRandomizedEquivalence(t *testing.T) {
+	host := "h"
+	var hostRoutes []Route
+	for i := 0; i < 50; i++ {
+		env := fmt.Sprintf("e%d", i%7)
+		prio := int32(1000 + (i*7)%500)
+		hostRoutes = append(hostRoutes,
+			Route{Path: fmt.Sprintf("/p%d", i%11), Type: RouteTypePrefix, Backend: fmt.Sprintf("b%d", i), Priority: prio, Headers: envHeader(env)},
+		)
+		if i%5 == 0 {
+			hostRoutes = append(hostRoutes,
+				Route{Path: fmt.Sprintf("/p%d", i%11), Type: RouteTypePrefix, Backend: fmt.Sprintf("shared%d", i), Priority: prio},
+			)
+		}
+	}
+	full := &RoutesConfig{Version: 1, Hosts: map[string][]Route{host: append([]Route(nil), hostRoutes...)}}
+	SortRoutes(full.Hosts[host])
+	_ = full.CompileRegexes()
+
+	part := &RoutesConfig{Version: 1, Hosts: map[string][]Route{host: append([]Route(nil), hostRoutes...)}}
+	SortRoutes(part.Hosts[host])
+	_ = part.CompileRegexes()
+	part.BuildPartitionIndex("env")
+
+	for e := 0; e < 9; e++ {
+		for p := 0; p < 13; p++ {
+			req := RequestMatch{
+				Path:    fmt.Sprintf("/p%d/sub", p),
+				Method:  "GET",
+				Headers: map[string]string{"env": fmt.Sprintf("e%d", e)},
+			}
+			want := full.FindRoute(host, req)
+			got := part.FindRoute(host, req)
+			if !sameRoute(got, want) {
+				t.Fatalf("divergence env=e%d path=/p%d/sub: got %s want %s", e, p, backendOf(got), backendOf(want))
+			}
+		}
+	}
+}
+
+func TestBuildPartitionIndexDisabledByDefault(t *testing.T) {
+	cfg := buildSandboxConfig(t, false)
+	if cfg.partitions != nil || cfg.partitionHeader != "" {
+		t.Fatal("partition index must stay nil when BuildPartitionIndex is not called")
+	}
+	// Empty header is an explicit no-op (clears any prior index).
+	cfg.BuildPartitionIndex("")
+	if cfg.partitions != nil || cfg.partitionHeader != "" {
+		t.Fatal("BuildPartitionIndex(\"\") must disable partitioning")
+	}
+}
+
+// buildLargeSandboxConfig emulates the sbx topology: many sandboxes share one
+// host, every route gated by its own "env" header, with a low-priority catch-all
+// per sandbox (the worst case — static-asset requests fall through to it).
+func buildLargeSandboxConfig(sandboxes, pathsPerSandbox int, partition bool) (*RoutesConfig, string) {
+	host := "magnific.com"
+	var hostRoutes []Route
+	for s := 0; s < sandboxes; s++ {
+		env := fmt.Sprintf("sbx-%d", s)
+		for p := 0; p < pathsPerSandbox; p++ {
+			hostRoutes = append(hostRoutes, Route{
+				Path:     fmt.Sprintf("/section-%d", p),
+				Type:     RouteTypePrefix,
+				Backend:  fmt.Sprintf("%s-b%d", env, p),
+				Priority: 1000,
+				Headers:  envHeader(env),
+			})
+		}
+		hostRoutes = append(hostRoutes, Route{
+			Path: "/", Type: RouteTypePrefix, Backend: env + "-catchall", Priority: 1, Headers: envHeader(env),
+		})
+	}
+	cfg := &RoutesConfig{Version: 1, Hosts: map[string][]Route{host: hostRoutes}}
+	SortRoutes(cfg.Hosts[host])
+	_ = cfg.CompileRegexes()
+	if partition {
+		cfg.BuildPartitionIndex("env")
+	}
+	return cfg, host
+}
+
+// BenchmarkFindRouteFullScan vs BenchmarkFindRoutePartitioned: a static-asset
+// request that only matches its sandbox catch-all, forcing a worst-case scan.
+func BenchmarkFindRouteFullScan(b *testing.B) {
+	cfg, host := buildLargeSandboxConfig(40, 80, false)
+	req := RequestMatch{Path: "/static/app.123.js", Method: "GET", Headers: map[string]string{"env": "sbx-20"}}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = cfg.FindRoute(host, req)
+	}
+}
+
+func BenchmarkFindRoutePartitioned(b *testing.B) {
+	cfg, host := buildLargeSandboxConfig(40, 80, true)
+	req := RequestMatch{Path: "/static/app.123.js", Method: "GET", Headers: map[string]string{"env": "sbx-20"}}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = cfg.FindRoute(host, req)
+	}
+}
+
+func sameRoute(a, b *Route) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.Backend == b.Backend && a.Path == b.Path && a.Type == b.Type
+}
+
+func backendOf(r *Route) string {
+	if r == nil {
+		return "<nil>"
+	}
+	return r.Backend
+}

--- a/pkg/routes/partition_test.go
+++ b/pkg/routes/partition_test.go
@@ -21,6 +21,9 @@ import (
 	"testing"
 )
 
+// testHost is the shared hostname used across the partition tests.
+const testHost = "example.com"
+
 // envHeader builds a single exact env header matcher.
 func envHeader(value string) []RouteHeaderMatch {
 	return []RouteHeaderMatch{{Name: "env", Value: value, Type: HeaderMatchExact}}
@@ -96,9 +99,10 @@ func TestRoutePartitionValue(t *testing.T) {
 // env-agnostic routes to exercise the unpartitioned-merge path.
 func buildSandboxConfig(t *testing.T, withPartition bool) *RoutesConfig {
 	t.Helper()
-	host := "magnific.com"
-	var hostRoutes []Route
-	for _, env := range []string{"sbx-a", "sbx-b", "sbx-c"} {
+	host := testHost
+	envs := []string{"sbx-a", "sbx-b", "sbx-c"}
+	hostRoutes := make([]Route, 0, len(envs)*3+2)
+	for _, env := range envs {
 		hostRoutes = append(hostRoutes,
 			Route{Path: "/images", Type: RouteTypeExact, Backend: env + "-images", Priority: 1000, Headers: envHeader(env)},
 			Route{Path: "/static", Type: RouteTypePrefix, Backend: env + "-static", Priority: 1000, Headers: envHeader(env)},
@@ -123,7 +127,7 @@ func buildSandboxConfig(t *testing.T, withPartition bool) *RoutesConfig {
 }
 
 func TestFindRoutePartitionEquivalence(t *testing.T) {
-	host := "magnific.com"
+	host := testHost
 	full := buildSandboxConfig(t, false)
 	part := buildSandboxConfig(t, true)
 
@@ -160,18 +164,26 @@ func TestFindRoutePartitionEquivalence(t *testing.T) {
 // TestFindRoutePartitionRandomizedEquivalence fuzzes a larger interleaved route
 // set to make sure the index never changes which route wins.
 func TestFindRoutePartitionRandomizedEquivalence(t *testing.T) {
-	host := "h"
-	var hostRoutes []Route
+	host := testHost
+	hostRoutes := make([]Route, 0, 60)
 	for i := 0; i < 50; i++ {
 		env := fmt.Sprintf("e%d", i%7)
 		prio := int32(1000 + (i*7)%500)
-		hostRoutes = append(hostRoutes,
-			Route{Path: fmt.Sprintf("/p%d", i%11), Type: RouteTypePrefix, Backend: fmt.Sprintf("b%d", i), Priority: prio, Headers: envHeader(env)},
-		)
+		path := fmt.Sprintf("/p%d", i%11)
+		hostRoutes = append(hostRoutes, Route{
+			Path:     path,
+			Type:     RouteTypePrefix,
+			Backend:  fmt.Sprintf("b%d", i),
+			Priority: prio,
+			Headers:  envHeader(env),
+		})
 		if i%5 == 0 {
-			hostRoutes = append(hostRoutes,
-				Route{Path: fmt.Sprintf("/p%d", i%11), Type: RouteTypePrefix, Backend: fmt.Sprintf("shared%d", i), Priority: prio},
-			)
+			hostRoutes = append(hostRoutes, Route{
+				Path:     path,
+				Type:     RouteTypePrefix,
+				Backend:  fmt.Sprintf("shared%d", i),
+				Priority: prio,
+			})
 		}
 	}
 	full := &RoutesConfig{Version: 1, Hosts: map[string][]Route{host: append([]Route(nil), hostRoutes...)}}
@@ -215,8 +227,8 @@ func TestBuildPartitionIndexDisabledByDefault(t *testing.T) {
 // host, every route gated by its own "env" header, with a low-priority catch-all
 // per sandbox (the worst case — static-asset requests fall through to it).
 func buildLargeSandboxConfig(sandboxes, pathsPerSandbox int, partition bool) (*RoutesConfig, string) {
-	host := "magnific.com"
-	var hostRoutes []Route
+	host := testHost
+	hostRoutes := make([]Route, 0, sandboxes*(pathsPerSandbox+1))
 	for s := 0; s < sandboxes; s++ {
 		env := fmt.Sprintf("sbx-%d", s)
 		for p := 0; p < pathsPerSandbox; p++ {

--- a/pkg/routes/types.go
+++ b/pkg/routes/types.go
@@ -158,6 +158,19 @@ type RequestMatch struct {
 type RoutesConfig struct {
 	Version int                `json:"version"`
 	Hosts   map[string][]Route `json:"hosts"`
+
+	// partitionHeader is the lowercased request-header name used to bucket
+	// routes for the fast-path lookup in FindRoute. Empty disables
+	// partitioning entirely (full ordered scan). Unexported, so it is never
+	// serialized to the ConfigMap and only matters inside the extproc.
+	partitionHeader string
+
+	// partitions indexes, per host, the candidate routes for each value of
+	// partitionHeader. Each candidate slice is a subset of Hosts[host] in the
+	// same sorted order, so scanning it yields the exact same first-match
+	// result as a full scan — just over far fewer routes. Built by
+	// BuildPartitionIndex; nil when partitioning is disabled.
+	partitions map[string]map[string][]*Route
 }
 
 // RouteType constants
@@ -279,6 +292,134 @@ func (rc *RoutesConfig) CompileRegexes() error {
 					q.compiledRegex = re
 				}
 			}
+		}
+	}
+	return nil
+}
+
+// BuildPartitionIndex (re)builds the per-host fast-path index keyed by the
+// value of the given request header. It must be called after the routes have
+// been sorted (SortRoutes) and regexes compiled, because the candidate slices
+// reference the routes in their final position and sorted order.
+//
+// An empty header disables partitioning: the index is cleared and FindRoute
+// falls back to the full ordered scan (the historical, unchanged behavior).
+// This keeps the optimization strictly opt-in — environments that do not set
+// the partition header are completely unaffected.
+//
+// Correctness: a request carrying header==v can only ever match routes that
+// either require that exact header value (a "partitioned" route) or place no
+// exact constraint on that header (an "unpartitioned" route — including routes
+// that match the header via regex). Each bucket is therefore the union of
+// those two sets, preserved in global sorted order, so scanning a bucket is
+// equivalent to scanning the full host list with all non-matching buckets
+// removed.
+func (rc *RoutesConfig) BuildPartitionIndex(header string) {
+	header = strings.ToLower(strings.TrimSpace(header))
+	rc.partitionHeader = header
+	rc.partitions = nil
+	if header == "" {
+		return
+	}
+
+	parts := make(map[string]map[string][]*Route, len(rc.Hosts))
+	for host := range rc.Hosts {
+		hostRoutes := rc.Hosts[host]
+
+		byVal := make(map[string][]*Route)
+		var unpartitioned []*Route
+		for i := range hostRoutes {
+			if v, ok := routePartitionValue(&hostRoutes[i], header); ok {
+				byVal[v] = append(byVal[v], &hostRoutes[i])
+			} else {
+				unpartitioned = append(unpartitioned, &hostRoutes[i])
+			}
+		}
+
+		// No route on this host constrains the partition header: a full scan is
+		// already optimal, so leave the host out of the index entirely.
+		if len(byVal) == 0 {
+			continue
+		}
+
+		// When env-agnostic routes exist they could match a request for any
+		// header value, so each bucket must include them, interleaved in the
+		// original sorted order. Re-scan once per value to preserve ordering.
+		if len(unpartitioned) > 0 {
+			for v := range byVal {
+				merged := make([]*Route, 0, len(byVal[v])+len(unpartitioned))
+				for i := range hostRoutes {
+					rv, ok := routePartitionValue(&hostRoutes[i], header)
+					if (ok && rv == v) || !ok {
+						merged = append(merged, &hostRoutes[i])
+					}
+				}
+				byVal[v] = merged
+			}
+		}
+
+		parts[host] = byVal
+	}
+	rc.partitions = parts
+}
+
+// routePartitionValue returns the exact value a route requires for the given
+// (lowercased) header, and whether the route is eligible for partitioning.
+// A route is partitionable only when it constrains the header with exactly one
+// exact-match criterion. Routes with no such header, a regex match on it, or
+// multiple criteria on it are treated as unpartitioned (they must be considered
+// for every header value).
+func routePartitionValue(r *Route, header string) (string, bool) {
+	value := ""
+	count := 0
+	for i := range r.Headers {
+		if !strings.EqualFold(r.Headers[i].Name, header) {
+			continue
+		}
+		if r.Headers[i].Type == HeaderMatchRegex {
+			return "", false
+		}
+		value = r.Headers[i].Value
+		count++
+	}
+	if count == 1 {
+		return value, true
+	}
+	return "", false
+}
+
+// FindRoute returns the first route matching req for the given normalized host
+// (port already stripped), or nil. When a partition index is present and the
+// request carries the partition header, only that value's candidate subset is
+// scanned; the result is identical to the full scan, just faster. Otherwise it
+// falls back to scanning every route for the host in sorted order.
+func (rc *RoutesConfig) FindRoute(host string, req RequestMatch) *Route {
+	hostRoutes, ok := rc.Hosts[host]
+	if !ok {
+		return nil
+	}
+
+	if rc.partitionHeader != "" && rc.partitions != nil {
+		if v := req.Headers[rc.partitionHeader]; v != "" {
+			if hostPart, ok := rc.partitions[host]; ok {
+				if candidates, ok := hostPart[v]; ok {
+					// The candidate set is the complete set of routes that can
+					// possibly match this header value, so a miss here is a real
+					// no-match — no need to fall back to the full scan.
+					for _, r := range candidates {
+						if r.Match(req) {
+							return r
+						}
+					}
+					return nil
+				}
+			}
+		}
+	}
+
+	for i := range hostRoutes {
+		if hostRoutes[i].Match(req) {
+			return &hostRoutes[i]
 		}
 	}
 	return nil


### PR DESCRIPTION
## Contexto

En sbx un único extproc (target `default`) mergea las rutas de ~38 namespaces de sandbox bajo hostnames compartidos (`magnific.com`, `www.magnific.com`), generando una tabla de rutas por host **del orden de cientos de miles de entradas**. `FindRoute` hace un **scan lineal** sobre toda esa tabla en cada request. Los estáticos son el peor caso: como no matchean reglas de path específicas, caen al catch-all `/` de cada sandbox (ordenado casi al final), recorriendo prácticamente toda la tabla → de ahí los **timeouts** que estamos viendo.

Cada ruta ya lleva una cabecera `env: sbx-<namespace>` que identifica unívocamente su sandbox, así que es una clave de partición natural (idea de Jaime Pérez Halcón).

## Qué hace este PR

Añade un **fast-path opt-in** en el lookup de rutas, indexado por una cabecera de request. Con `--route-partition-header=env`, las rutas se indexan por host según el valor de esa cabecera, de modo que un request se compara **solo contra las rutas que comparten su valor**, en vez de scanear todas las del host.

- **Desactivado por defecto** (cabecera vacía) → el comportamiento de producción **no cambia**. Se activa solo añadiendo el flag a los `values` del entorno (sbx).
- **Equivalencia demostrable con el scan completo:** cada bucket es la unión de (rutas que exigen ese valor exacto de cabecera) ∪ (rutas sin restricción exacta sobre esa cabecera — incluidas las de regex), preservando el orden global de prioridad. El resultado de *first-match* es idéntico; solo cambia cuántas rutas se recorren.

## Resultados (benchmark incluido)

Escenario sbx-like (40 sandboxes × 80 paths, request de estático que cae al catch-all):

| | ns/op | allocs/op |
|---|---|---|
| Full scan (actual) | 137704 | 0 |
| Particionado | 4016 | 0 |

≈ **34× más rápido** en el peor caso, sin allocations extra en el hot path.

## Cómo activarlo en sbx

Añadir a los `args` del extproc en los values de sbx (ejemplo ya documentado y comentado en `chart/values.yaml`):

```yaml
- --route-partition-header=env
```

## Cambios

- `pkg/routes/types.go`: índice `partitions` en `RoutesConfig`, `BuildPartitionIndex`, `routePartitionValue` y `FindRoute` unificado (fast-path + fallback a scan completo).
- `pkg/routes/{loader,k8s_loader}.go`: construyen el índice tras `CompileRegexes` (no-op si la cabecera está vacía) y delegan el lookup en `RoutesConfig.FindRoute`.
- `internal/extproc/{config,server}.go` + `cmd/extproc/main.go`: nuevo flag `--route-partition-header`.
- `chart/values.yaml`: ejemplo documentado (comentado).
- `pkg/routes/partition_test.go`: tests de equivalencia (incl. fuzz interleaved) + benchmark.

## Verificación

- `go build ./...`, `go vet ./...`, `go test ./...` ✅
- Tests de equivalencia: el índice devuelve exactamente la misma ruta que el scan completo para todas las combinaciones env × path × método probadas (incluyendo env desconocido, env vacío y rutas env-agnósticas).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the request hot path for route selection when the flag is enabled; incorrect indexing could mis-route traffic, though default behavior is unchanged and equivalence tests cover the new path.
> 
> **Overview**
> Adds an **opt-in fast path** for route lookup when one extproc serves huge per-host route tables (e.g. sandbox envs keyed by an `env` header). With `--route-partition-header` set, routes are indexed by host and header value after load; requests that carry that header are matched only against the corresponding candidate slice (plus env-agnostic routes), preserving the same first-match ordering as a full scan.
> 
> **Off by default** — empty header keeps today’s linear scan. Wiring runs through `ServerConfig` / `K8sLoader` and file `Loader`, which call `RoutesConfig.BuildPartitionIndex` and delegate lookup to unified `RoutesConfig.FindRoute`. Helm `values.yaml` documents the flag (commented example).
> 
> Tests assert partition vs full-scan equivalence (including fuzz) and include benchmarks for the sbx-like worst case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 847c51ff175bd2758ccacd52b3741950bb2dc007. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->