### PR TITLE
perf: recortar la CPU del extproc por churn de ConfigMaps (debounce + ConfigMaps deterministas)

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -222,6 +222,10 @@ externalProcessors:
       # only against routes sharing its value instead of scanning every route
       # for the host. Leave unset/empty to keep the default full-scan behavior.
       # - --route-partition-header=env
+      # Coalesce ConfigMap change events: rebuild the route table at most once
+      # per this window instead of once per event. Protects CPU when many
+      # ConfigMaps churn rapidly (large sandbox environments). Default 2s.
+      # - --routes-reload-debounce=2s
       - --grpc-max-recv-msg-size=4194304
       - --grpc-max-send-msg-size=4194304
       - --grpc-max-concurrent-streams=1000

--- a/cmd/extproc/main.go
+++ b/cmd/extproc/main.go
@@ -52,6 +52,10 @@ func main() {
 		"Request header used to index/partition routes for faster lookup "+
 			"(empty = disabled, full scan). Set e.g. to 'env' in sandbox environments "+
 			"where one extproc serves many route sets keyed by that header.")
+	flag.DurationVar(&config.RoutesReloadDebounce, "routes-reload-debounce", config.RoutesReloadDebounce,
+		"Debounce window for coalescing ConfigMap change events before rebuilding "+
+			"the route table (0 = rebuild on every event). Caps full rebuilds at one "+
+			"per window under churn.")
 	flag.StringVar(&config.MetricsAddr, "metrics-addr", config.MetricsAddr,
 		"Address to expose Prometheus metrics on (empty to disable)")
 

--- a/internal/controller/customhttproute/determinism_test.go
+++ b/internal/controller/customhttproute/determinism_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2024-2026 Freepik Company S.L.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package customhttproute
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/freepik-company/customrouter/api/v1alpha1"
+)
+
+// sharedHost is the hostname every CHR in the determinism test contributes to,
+// so their routes merge into one host's route slice.
+const sharedHost = "shared.example.com"
+
+// chrForHost builds a CustomHTTPRoute contributing a single route to sharedHost.
+func chrForHost(ns, name, path string) *v1alpha1.CustomHTTPRoute {
+	return &v1alpha1.CustomHTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns, UID: types.UID(ns + "-" + name)},
+		Spec: v1alpha1.CustomHTTPRouteSpec{
+			Hostnames: []string{sharedHost},
+			TargetRef: v1alpha1.TargetRef{Name: "default"},
+			Rules: []v1alpha1.Rule{
+				{
+					BackendRefs: []v1alpha1.BackendRef{{Name: "svc", Namespace: ns, Port: 80}},
+					Matches:     []v1alpha1.PathMatch{{Path: path, Type: "Prefix"}},
+				},
+			},
+		},
+	}
+}
+
+// dumpTargetConfigMaps returns the concatenated routes.json of every ConfigMap
+// for the target, ordered by ConfigMap name, so two rebuilds can be compared
+// byte-for-byte.
+func dumpTargetConfigMaps(t *testing.T, r *CustomHTTPRouteReconciler) string {
+	t.Helper()
+	list := &corev1.ConfigMapList{}
+	if err := r.List(context.Background(), list); err != nil {
+		t.Fatalf("listing ConfigMaps: %v", err)
+	}
+	names := make([]string, 0, len(list.Items))
+	data := make(map[string]string, len(list.Items))
+	for i := range list.Items {
+		cm := &list.Items[i]
+		if cm.Labels[configMapTargetLabel] != "default" {
+			continue
+		}
+		names = append(names, cm.Name)
+		data[cm.Name] = cm.Data[routesDataKey]
+	}
+	sort.Strings(names)
+	var b strings.Builder
+	for _, n := range names {
+		b.WriteString(n)
+		b.WriteString("=")
+		b.WriteString(data[n])
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// TestRebuildConfigMapsForTarget_Deterministic is a regression guard for the
+// ConfigMap-churn fix: rebuilding the same set of CustomHTTPRoutes must produce
+// byte-identical ConfigMaps every time. Equal-priority routes from several CHRs
+// merge into one host's slice; if their order is not pinned deterministically
+// the serialized bytes differ between reconciles, the content-hash dedup misses,
+// and every reconcile rewrites the ConfigMaps — the churn that forces extproc
+// replicas to constantly reload. The controller pins this by sorting the routes
+// by (namespace, name) before expansion.
+func TestRebuildConfigMapsForTarget_Deterministic(t *testing.T) {
+	// Equal-length, distinct paths so SortRoutes' priority/type/length keys are
+	// all tied and the final order is decided purely by the (namespace, name)
+	// ordering of the source CHRs that the controller pins.
+	objs := []runtime.Object{
+		chrForHost("ns-c", "route-1", "/c1"),
+		chrForHost("ns-a", "route-2", "/a2"),
+		chrForHost("ns-b", "route-1", "/b1"),
+		chrForHost("ns-a", "route-1", "/a1"),
+	}
+	r := newReconciler(objs...)
+	ctx := context.Background()
+
+	if err := r.rebuildConfigMapsForTarget(ctx, "default"); err != nil {
+		t.Fatalf("first rebuild failed: %v", err)
+	}
+	first := dumpTargetConfigMaps(t, r)
+
+	for i := 0; i < 5; i++ {
+		if err := r.rebuildConfigMapsForTarget(ctx, "default"); err != nil {
+			t.Fatalf("rebuild %d failed: %v", i, err)
+		}
+		if got := dumpTargetConfigMaps(t, r); got != first {
+			t.Fatalf("rebuild %d produced different ConfigMap bytes:\nfirst:\n%s\ngot:\n%s", i, first, got)
+		}
+	}
+
+	// The merged routes for the shared host must be ordered by (namespace,name)
+	// of their source CHR: ns-a/route-1, ns-a/route-2, ns-b/route-1, ns-c/route-1
+	// -> paths /a1, /a2, /b1, /c1 — independent of the order the routes were listed.
+	wantOrder := []string{`"path":"/a1"`, `"path":"/a2"`, `"path":"/b1"`, `"path":"/c1"`}
+	prev := -1
+	for _, marker := range wantOrder {
+		idx := strings.Index(first, marker)
+		if idx < 0 {
+			t.Fatalf("expected %s in serialized routes:\n%s", marker, first)
+		}
+		if idx < prev {
+			t.Fatalf("routes not ordered deterministically by source CHR; %s appears out of order:\n%s", marker, first)
+		}
+		prev = idx
+	}
+}

--- a/internal/controller/customhttproute/sync.go
+++ b/internal/controller/customhttproute/sync.go
@@ -306,6 +306,22 @@ func (r *CustomHTTPRouteReconciler) rebuildConfigMapsForTarget(ctx context.Conte
 		}
 	}
 
+	// Sort the routes deterministically by (namespace, name). The cache's
+	// field-indexer List returns items in a non-deterministic order (it
+	// iterates an internal map), so without this the per-host merge order of
+	// equal-priority routes changes between reconciles. That makes the
+	// serialized ConfigMap bytes differ even when the logical route set is
+	// unchanged, defeating the content-hash dedup in upsertSingleConfigMap and
+	// rewriting ConfigMaps on every reconcile — churn that forces every extproc
+	// replica to reload the full route table. Stable input here yields stable
+	// output (ExpandRoutes and SortRoutes are deterministic on ordered input).
+	sort.Slice(targetRoutes, func(i, j int) bool {
+		if targetRoutes[i].Namespace != targetRoutes[j].Namespace {
+			return targetRoutes[i].Namespace < targetRoutes[j].Namespace
+		}
+		return targetRoutes[i].Name < targetRoutes[j].Name
+	})
+
 	// Track active ConfigMap names for this target
 	activeNames := make(map[string]bool)
 

--- a/internal/extproc/config.go
+++ b/internal/extproc/config.go
@@ -82,6 +82,13 @@ type ServerConfig struct {
 	// keyed by "env"). Empty (default) keeps the full-scan behavior, so it is a
 	// no-op unless explicitly set.
 	RoutePartitionHeader string
+
+	// RoutesReloadDebounce coalesces ConfigMap change events: after a change,
+	// the loader waits this long (absorbing further changes) before rebuilding
+	// the route table once, capping full rebuilds at one per window under churn.
+	// This protects CPU when many ConfigMaps change rapidly (e.g. large
+	// sandbox environments). Zero rebuilds on every event.
+	RoutesReloadDebounce time.Duration
 }
 
 // DefaultServerConfig returns a ServerConfig with production-ready defaults
@@ -99,5 +106,6 @@ func DefaultServerConfig() *ServerConfig {
 		MaxConnectionAgeGrace: 10 * time.Second, // Grace period for in-flight requests
 		AccessLogEnabled:      true,
 		MetricsAddr:           ":9090",
+		RoutesReloadDebounce:  2 * time.Second,
 	}
 }

--- a/internal/extproc/server.go
+++ b/internal/extproc/server.go
@@ -60,6 +60,7 @@ func NewServer(config *ServerConfig, logger *zap.Logger) (*Server, error) {
 		TargetName:      config.TargetName,
 		Namespace:       config.RoutesNamespace,
 		PartitionHeader: config.RoutePartitionHeader,
+		ReloadDebounce:  config.RoutesReloadDebounce,
 	})
 
 	// Initial load
@@ -130,6 +131,7 @@ func (s *Server) Start(ctx context.Context) error {
 		zap.String("target_name", s.config.TargetName),
 		zap.String("routes_namespace", s.config.RoutesNamespace),
 		zap.String("route_partition_header", s.config.RoutePartitionHeader),
+		zap.Duration("routes_reload_debounce", s.config.RoutesReloadDebounce),
 		zap.Int("max_recv_msg_size", s.config.MaxRecvMsgSize),
 		zap.Int("max_send_msg_size", s.config.MaxSendMsgSize),
 		zap.Uint32("max_concurrent_streams", s.config.MaxConcurrentStreams),

--- a/pkg/routes/k8s_loader.go
+++ b/pkg/routes/k8s_loader.go
@@ -49,10 +49,17 @@ type K8sLoader struct {
 	targetName      string
 	namespace       string
 	partitionHeader string
+	reloadDebounce  time.Duration
 
 	config   *RoutesConfig
 	mu       sync.RWMutex
 	onChange func(*RoutesConfig)
+
+	// dirty signals the reload loop that at least one ConfigMap changed since
+	// the last rebuild. It is buffered with capacity 1 and written
+	// non-blockingly, so a burst of watch events collapses into a single
+	// pending rebuild instead of one rebuild per event.
+	dirty chan struct{}
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -72,6 +79,13 @@ type K8sLoaderConfig struct {
 	// in FindRoute (see RoutesConfig.BuildPartitionIndex). Empty disables it,
 	// leaving the historical full-scan behavior untouched.
 	PartitionHeader string
+
+	// ReloadDebounce coalesces ConfigMap change events: after a change, the
+	// loader waits this long (absorbing further changes) before rebuilding the
+	// route table once. This caps full rebuilds at one per window under churn
+	// instead of one per ConfigMap write. Zero rebuilds on every event (legacy
+	// behaviour), though bursts still collapse via the buffered signal channel.
+	ReloadDebounce time.Duration
 }
 
 // NewK8sLoader creates a new Kubernetes ConfigMap loader
@@ -82,10 +96,12 @@ func NewK8sLoader(client kubernetes.Interface, config K8sLoaderConfig) *K8sLoade
 		targetName:      config.TargetName,
 		namespace:       config.Namespace,
 		partitionHeader: config.PartitionHeader,
+		reloadDebounce:  config.ReloadDebounce,
 		config: &RoutesConfig{
 			Version: 1,
 			Hosts:   make(map[string][]Route),
 		},
+		dirty:  make(chan struct{}, 1),
 		ctx:    ctx,
 		cancel: cancel,
 	}
@@ -198,9 +214,56 @@ func (l *K8sLoader) FindRoute(host string, req RequestMatch) *Route {
 func (l *K8sLoader) Watch(onChange func(*RoutesConfig)) error {
 	l.onChange = onChange
 
+	go l.reloadLoop()
 	go l.watchLoop()
 
 	return nil
+}
+
+// signalReload marks the config dirty without blocking. Multiple events between
+// rebuilds collapse into the single buffered slot.
+func (l *K8sLoader) signalReload() {
+	select {
+	case l.dirty <- struct{}{}:
+	default:
+	}
+}
+
+// reloadLoop performs the actual rebuilds, decoupled from the watch event rate.
+// On the first dirty signal it (optionally) waits out the debounce window,
+// absorbing any further signals, then rebuilds the route table exactly once.
+// Under continuous ConfigMap churn this caps rebuilds at one per debounce
+// window instead of one per event — the rebuild walks the entire route set, so
+// this is the difference between idle and a pegged CPU on large configs.
+func (l *K8sLoader) reloadLoop() {
+	for {
+		select {
+		case <-l.ctx.Done():
+			return
+		case <-l.dirty:
+		}
+
+		if l.reloadDebounce > 0 {
+			timer := time.NewTimer(l.reloadDebounce)
+		absorb:
+			for {
+				select {
+				case <-l.ctx.Done():
+					timer.Stop()
+					return
+				case <-l.dirty:
+					// Keep absorbing within the same window; the timer is not
+					// reset, so a steady stream still rebuilds once per window.
+				case <-timer.C:
+					break absorb
+				}
+			}
+		}
+
+		if err := l.Load(); err == nil && l.onChange != nil {
+			l.onChange(l.GetConfig())
+		}
+	}
 }
 
 func (l *K8sLoader) watchLoop() {
@@ -248,10 +311,9 @@ func (l *K8sLoader) handleWatchEvents(watcher watch.Interface) {
 
 			switch event.Type {
 			case watch.Added, watch.Modified, watch.Deleted:
-				// Reload all ConfigMaps for this target
-				if err := l.Load(); err == nil && l.onChange != nil {
-					l.onChange(l.config)
-				}
+				// Hand off to the debounced reload loop instead of rebuilding
+				// inline on every event.
+				l.signalReload()
 
 			case watch.Error:
 				// Watch error, need to restart

--- a/pkg/routes/reload_test.go
+++ b/pkg/routes/reload_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2024-2026 Freepik Company S.L.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package routes
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+func routesConfigMap() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "customrouter-routes-default-0",
+			Namespace: "default",
+			Labels: map[string]string{
+				configMapManagedByLabel: configMapManagedByValue,
+				configMapTargetLabel:    "default",
+			},
+		},
+		Data: map[string]string{
+			routesDataKey: `{"version":1,"hosts":{"a.com":[{"path":"/","type":"prefix","backend":"svc:80"}]}}`,
+		},
+	}
+}
+
+// countingClient returns a fake clientset that counts ConfigMap list calls,
+// which is the per-rebuild work signal (each Load lists once).
+func countingClient() (*fake.Clientset, *int32) {
+	cs := fake.NewSimpleClientset(routesConfigMap())
+	var lists int32
+	cs.PrependReactor("list", "configmaps", func(clienttesting.Action) (bool, k8sruntime.Object, error) {
+		atomic.AddInt32(&lists, 1)
+		return false, nil, nil // fall through to the tracker's real list
+	})
+	return cs, &lists
+}
+
+// TestReloadLoopCoalescesBursts asserts that a burst of change signals collapses
+// into at most a couple of rebuilds when a debounce window is set, instead of
+// one rebuild per signal. This is the protection against the ConfigMap churn
+// pinning CPU when many ConfigMaps change rapidly.
+func TestReloadLoopCoalescesBursts(t *testing.T) {
+	cs, lists := countingClient()
+	l := NewK8sLoader(cs, K8sLoaderConfig{TargetName: "default", ReloadDebounce: 80 * time.Millisecond})
+	defer func() { _ = l.Close() }()
+
+	go l.reloadLoop()
+
+	// 50 change events spread over ~50ms — well inside a single 80ms window.
+	for i := 0; i < 50; i++ {
+		l.signalReload()
+		time.Sleep(time.Millisecond)
+	}
+	time.Sleep(250 * time.Millisecond)
+
+	n := atomic.LoadInt32(lists)
+	if n == 0 {
+		t.Fatal("expected at least one rebuild after signalling")
+	}
+	if n > 3 {
+		t.Fatalf("expected burst of 50 signals to coalesce into <=3 rebuilds, got %d", n)
+	}
+}
+
+// TestReloadLoopRebuildsWithoutDebounce asserts the loop still rebuilds when no
+// debounce is configured (backward-compatible behaviour), and that the buffered
+// signal channel keeps it from blocking the watch goroutine.
+func TestReloadLoopRebuildsWithoutDebounce(t *testing.T) {
+	cs, lists := countingClient()
+	l := NewK8sLoader(cs, K8sLoaderConfig{TargetName: "default", ReloadDebounce: 0})
+	defer func() { _ = l.Close() }()
+
+	go l.reloadLoop()
+
+	l.signalReload()
+	deadline := time.After(2 * time.Second)
+	for atomic.LoadInt32(lists) == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("reload loop did not rebuild within 2s")
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+}
+
+// TestSignalReloadNeverBlocks verifies the non-blocking signal: many rapid
+// signals with no consumer running must not deadlock (the buffered slot
+// absorbs the first, the rest are dropped).
+func TestSignalReloadNeverBlocks(t *testing.T) {
+	cs, _ := countingClient()
+	l := NewK8sLoader(cs, K8sLoaderConfig{TargetName: "default"})
+	defer func() { _ = l.Close() }()
+
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 1000; i++ {
+			l.signalReload()
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("signalReload blocked")
+	}
+}


### PR DESCRIPTION
## Contexto / diagnóstico

Investigando por qué el extproc de sbx consume **~1.3 cores por pod en reposo** (con ~0 req/s real), las métricas Go fueron concluyentes:

- En una ventana con **0 requests**: **390 MB/s de asignación** y **1.39 cores**. La CPU **no** es del matching de requests.
- El extproc tiene cargadas **~847.420 rutas** (un host, ~423k) y **reconstruye TODA la tabla en cada evento de ConfigMap, sin debounce**.
- Las escrituras de ConfigMap eran ~1.3/s y **casi todas espurias**: el controller re-emitía el **mismo conjunto de rutas en distinto orden** cada reconcile → el hash de contenido por partición cambiaba → reescritura del CM aunque nada cambiara lógicamente. (Verificado en cluster: un CM con las mismas 325 rutas reordenadas entre dos lecturas con 3s de diferencia.)

Resultado: ~1.3 rebuilds completos/s → 1.3 cores, independiente del tráfico.

## Cambios

**1. extproc — debounce/coalescing del reload** (`pkg/routes/k8s_loader.go`)
Los eventos del watch ahora señalan un canal con buffer; una única goroutine de reload espera una ventana configurable (`--routes-reload-debounce`, **default 2s**), absorbe más eventos y reconstruye **una sola vez**. Limita los rebuilds completos a uno por ventana bajo churn, en lugar de uno por evento.

**2. controller — ConfigMaps deterministas** (`internal/controller/customhttproute/sync.go`)
`r.List(MatchingFields)` (cache field-indexer) devuelve los CHR en orden **no determinista** → rutas de igual prioridad se mergeaban en distinto orden → bytes flapeantes → la dedup por hash (`upsertSingleConfigMap`) no servía. Se ordenan los CHR por **(namespace, name)** antes de expandir: mismo input → ConfigMaps byte-idénticos → la dedup suprime de verdad las escrituras no-op.

Juntos: (2) elimina la fuente de escrituras espurias; (1) acota el coste de rebuild sea cual sea la tasa de escritura.

## Seguridad / impacto

- Ambos **default-safe**. El debounce solo retrasa la propagación de config la ventana (2s); irrelevante para routing.
- (2) no cambia semántica de match: solo fija el orden de rutas de igual prioridad (que antes era aleatorio por proceso) — de hecho hace el first-match determinista.
- No toca el CRD ni los manifiestos. El flag se documenta (comentado) en `chart/values.yaml`.

## Tests

- `pkg/routes/reload_test.go`: coalescing (ráfaga de 50 señales → ≤3 rebuilds), rebuild sin debounce, señal no bloqueante.
- `internal/controller/customhttproute/determinism_test.go`: rebuild repetido → ConfigMaps byte-idénticos + orden por (namespace, name).
- `go build`, `go vet`, `go test ./...` y golangci-lint en verde.

## Nota de validación

El bug de orden no-determinista del indexer **no es reproducible con el fake client** (que ordena el List), así que la confirmación real del recorte de CPU/churn se hará **re-midiendo en sbx** tras desplegar (esperado: rebuilds de ~1.3/s → ~0, CPU de ~1.3 cores → casi idle).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how quickly route config reaches extproc (up to the debounce window) and pins first-match order among equal-priority routes; core request matching logic is unchanged but large sandbox deployments should validate CPU and propagation after deploy.
> 
> **Overview**
> Cuts **idle CPU on extproc** when route ConfigMaps churn by fixing spurious controller writes and coalescing full route-table rebuilds in the loader.
> 
> **Controller:** Before expanding routes, `CustomHTTPRoute` resources for a target are sorted by **(namespace, name)** so merged `routes.json` is byte-stable across reconciles. That lets `upsertSingleConfigMap` content-hash dedup skip no-op updates instead of rewriting ConfigMaps whose only difference was route order.
> 
> **extproc:** ConfigMap watch events no longer call `Load()` inline; they **`signalReload`** into a dedicated **`reloadLoop`** that optionally waits **`--routes-reload-debounce`** (default **2s**, `0` = legacy per-event rebuilds) and rebuilds at most once per window. Wired through `ServerConfig`, CLI, Helm values comment, and startup logging.
> 
> **Tests:** `determinism_test.go` for stable ConfigMap bytes; `reload_test.go` for burst coalescing, zero debounce, and non-blocking signals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8c42457ab643dbd2149f8044074b7e83277cc79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->