### PR TITLE
perf(controller): coalescing single-flight de rebuilds por target (arregla OOM del operator)

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -64,6 +64,12 @@ operator:
   args:
     - --leader-elect
     - --health-probe-bind-address=:8081
+    # Minimum interval between ConfigMap rebuilds for the same target. Raising
+    # it reduces rebuild frequency (CPU/memory) when many CustomHTTPRoutes share
+    # a target and churn rapidly (large sandbox environments), at the cost of
+    # slightly slower route propagation. Rebuilds are also single-flight
+    # coalesced per target, so a resync burst never runs concurrent rebuilds.
+    # - --rebuild-cooldown=5s
 
   # -- Node selector
   nodeSelector: {}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -69,6 +69,7 @@ func main() {
 	var enableHTTP2 bool
 	var routesConfigMapNamespace string
 	var maxConcurrentReconciles int
+	var rebuildCooldown time.Duration
 	var enableWebhooks bool
 	var webhookConfigName string
 	var webhookServiceName string
@@ -95,6 +96,10 @@ func main() {
 		"The namespace where route ConfigMaps will be stored")
 	flag.IntVar(&maxConcurrentReconciles, "max-concurrent-reconciles", 5,
 		"Maximum number of concurrent reconciliations for CustomHTTPRoute controller")
+	flag.DurationVar(&rebuildCooldown, "rebuild-cooldown", customhttproute.DefaultRebuildCooldown,
+		"Minimum interval between ConfigMap rebuilds for the same target. Higher values reduce "+
+			"rebuild frequency (CPU/memory) under churn at the cost of slower route propagation. "+
+			"0 uses the default; negative disables throttling.")
 	flag.BoolVar(&enableWebhooks, "enable-webhooks", false,
 		"Enable validating admission webhooks for hostname conflict detection")
 	flag.StringVar(&webhookConfigName, "webhook-config-name", "",
@@ -250,6 +255,7 @@ func main() {
 		Scheme:                  mgr.GetScheme(),
 		ConfigMapNamespace:      routesConfigMapNamespace,
 		MaxConcurrentReconciles: maxConcurrentReconciles,
+		RebuildCooldown:         rebuildCooldown,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "CustomHTTPRoute")
 		os.Exit(1)

--- a/internal/controller/customhttproute/coalesce_test.go
+++ b/internal/controller/customhttproute/coalesce_test.go
@@ -25,6 +25,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -32,128 +33,87 @@ import (
 	"github.com/freepik-company/customrouter/api/v1alpha1"
 )
 
-// TestRebuildSingleFlightPrimitives verifies the begin/finish/release state
-// machine that drives per-target rebuild coalescing.
-func TestRebuildSingleFlightPrimitives(t *testing.T) {
-	r := &CustomHTTPRouteReconciler{}
-
-	if !r.tryBeginRebuild("t") {
-		t.Fatal("first tryBeginRebuild should take ownership")
-	}
-	// While in progress, another caller must not take ownership and must record pending.
-	if r.tryBeginRebuild("t") {
-		t.Fatal("second tryBeginRebuild should not take ownership while in progress")
-	}
-	// Owner sees the pending flag and is told to loop once more.
-	if !r.finishOrContinueRebuild("t") {
-		t.Fatal("finishOrContinueRebuild should report pending → continue")
-	}
-	// Nothing pending now → ownership released.
-	if r.finishOrContinueRebuild("t") {
-		t.Fatal("finishOrContinueRebuild should report no pending → release")
-	}
-	// Released → ownership available again.
-	if !r.tryBeginRebuild("t") {
-		t.Fatal("after release, tryBeginRebuild should take ownership again")
-	}
-	// releaseRebuild (error path) must free ownership.
-	r.releaseRebuild("t")
-	if !r.tryBeginRebuild("t") {
-		t.Fatal("after releaseRebuild, tryBeginRebuild should take ownership")
-	}
-	r.releaseRebuild("t")
-
-	// Different targets are independent.
-	if !r.tryBeginRebuild("a") || !r.tryBeginRebuild("b") {
-		t.Fatal("distinct targets must not block each other")
-	}
-}
-
-// TestCoalescedRebuildReportsPerformed locks the contract the reconcile relies
-// on: the call returns performed=true when it ran the rebuild and false when it
-// delegated to an in-flight owner (so the reconcile knows whether it may mark
-// the resource synced or must requeue).
-func TestCoalescedRebuildReportsPerformed(t *testing.T) {
-	route := &v1alpha1.CustomHTTPRoute{
-		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "uid"},
+func routeForTarget(target, path string) *v1alpha1.CustomHTTPRoute {
+	return &v1alpha1.CustomHTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "r-" + path[1:], Namespace: "ns", UID: types.UID(target + path)},
 		Spec: v1alpha1.CustomHTTPRouteSpec{
 			Hostnames: []string{"a.example.com"},
-			TargetRef: v1alpha1.TargetRef{Name: "default"},
+			TargetRef: v1alpha1.TargetRef{Name: target},
 			Rules: []v1alpha1.Rule{{
 				BackendRefs: []v1alpha1.BackendRef{{Name: "svc", Namespace: "ns", Port: 80}},
-				Matches:     []v1alpha1.PathMatch{{Path: "/a", Type: "Exact"}},
+				Matches:     []v1alpha1.PathMatch{{Path: path, Type: "Exact"}},
 			}},
 		},
 	}
-	r := newReconciler(route)
+}
+
+// TestTargetTryLock verifies the per-target single-flight lock.
+func TestTargetTryLock(t *testing.T) {
+	r := &CustomHTTPRouteReconciler{}
+	if !r.targetTryLock("t") {
+		t.Fatal("first lock should succeed")
+	}
+	if r.targetTryLock("t") {
+		t.Fatal("second lock should fail while held")
+	}
+	if !r.targetTryLock("b") {
+		t.Fatal("distinct target must not be blocked")
+	}
+	r.targetUnlock("t")
+	if !r.targetTryLock("t") {
+		t.Fatal("lock should be available after unlock")
+	}
+	r.targetUnlock("t")
+	r.targetUnlock("b")
+}
+
+// TestClearTargetStateKeepsLock is the regression for the empty-target path:
+// clearTargetState runs inside rebuildConfigMapsForTarget while rebuildTarget
+// holds the per-target lock, so it must NOT release it (doing so would let a
+// concurrent reconcile start a parallel rebuild).
+func TestClearTargetStateKeepsLock(t *testing.T) {
+	r := &CustomHTTPRouteReconciler{}
+	if !r.targetTryLock("t") {
+		t.Fatal("setup: should acquire lock")
+	}
+	r.clearTargetState("t")
+	if r.targetTryLock("t") {
+		t.Fatal("clearTargetState must not release the per-target rebuild lock")
+	}
+	r.targetUnlock("t")
+}
+
+// TestRebuildTargetDefers checks rebuildTarget returns a positive wait (and does
+// not rebuild) when the target is in cooldown or its lock is held.
+func TestRebuildTargetDefers(t *testing.T) {
+	r := newReconciler(routeForTarget("default", "/a"))
 	ctx := context.Background()
 
-	performed, err := r.coalescedRebuildForTarget(ctx, "default")
-	if err != nil || !performed {
-		t.Fatalf("owner call should perform the rebuild: performed=%v err=%v", performed, err)
+	if wait, err := r.rebuildTarget(ctx, "default", false); err != nil || wait != 0 {
+		t.Fatalf("first rebuild should perform: wait=%v err=%v", wait, err)
+	}
+	// Within the cooldown window the next rebuild must defer.
+	if wait, err := r.rebuildTarget(ctx, "default", false); err != nil || wait <= 0 {
+		t.Fatalf("rebuild within cooldown should defer: wait=%v err=%v", wait, err)
 	}
 
-	// With another reconcile holding ownership, the call must delegate.
-	if !r.tryBeginRebuild("default") {
-		t.Fatal("setup: expected to take ownership")
+	// With the lock held by someone else, defer regardless of cooldown.
+	r2 := newReconciler(routeForTarget("default", "/a"))
+	r2.RebuildCooldown = -1 // disable cooldown to isolate the lock behaviour
+	if !r2.targetTryLock("default") {
+		t.Fatal("setup: should hold the lock")
 	}
-	performed, err = r.coalescedRebuildForTarget(ctx, "default")
-	if err != nil {
-		t.Fatalf("delegated call should not error: %v", err)
+	if wait, err := r2.rebuildTarget(ctx, "default", false); err != nil || wait <= 0 {
+		t.Fatalf("rebuild while lock held should defer: wait=%v err=%v", wait, err)
 	}
-	if performed {
-		t.Fatal("call should delegate (performed=false) while another owner is in flight")
-	}
-	r.releaseRebuild("default")
+	r2.targetUnlock("default")
 }
 
-// TestClearTargetStateKeepsSingleFlightOwnership is the regression for the
-// empty-target path: clearTargetState runs inside rebuildConfigMapsForTarget
-// while coalescedRebuildForTarget still holds ownership, so it must NOT release
-// the single-flight flags (doing so would let a concurrent reconcile start a
-// parallel rebuild).
-func TestClearTargetStateKeepsSingleFlightOwnership(t *testing.T) {
-	r := &CustomHTTPRouteReconciler{}
-
-	if !r.tryBeginRebuild("t") {
-		t.Fatal("setup: should take ownership")
-	}
-	// Simulate the empty-target cleanup running mid-rebuild.
-	r.clearTargetState("t")
-	// Ownership must still be held: a concurrent reconcile must not be able to
-	// begin a parallel rebuild (this call returns false and records pending).
-	if r.tryBeginRebuild("t") {
-		t.Fatal("clearTargetState must not release single-flight ownership mid-rebuild")
-	}
-	// That blocked attempt set pending, so the owner loops once...
-	if !r.finishOrContinueRebuild("t") {
-		t.Fatal("expected pending (from the blocked begin) → continue")
-	}
-	// ...then releases cleanly.
-	if r.finishOrContinueRebuild("t") {
-		t.Fatal("expected no pending → release")
-	}
-	if !r.tryBeginRebuild("t") {
-		t.Fatal("after the owner finished, ownership should be available again")
-	}
-	r.releaseRebuild("t")
-}
-
-// TestCoalescedRebuildNoConcurrentRebuilds runs many concurrent
-// coalescedRebuildForTarget calls for the same target and asserts the actual
-// rebuild work never runs concurrently (which would multiply operator memory).
-func TestCoalescedRebuildNoConcurrentRebuilds(t *testing.T) {
-	route := &v1alpha1.CustomHTTPRoute{
-		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "uid"},
-		Spec: v1alpha1.CustomHTTPRouteSpec{
-			Hostnames: []string{"a.example.com"},
-			TargetRef: v1alpha1.TargetRef{Name: "default"},
-			Rules: []v1alpha1.Rule{{
-				BackendRefs: []v1alpha1.BackendRef{{Name: "svc", Namespace: "ns", Port: 80}},
-				Matches:     []v1alpha1.PathMatch{{Path: "/a", Type: "Exact"}},
-			}},
-		},
-	}
+// TestRebuildTargetNoConcurrentRebuilds runs many goroutines that each retry
+// rebuildTarget until it performs, with the cooldown disabled so only the lock
+// gates concurrency. The actual rebuild work must never overlap.
+func TestRebuildTargetNoConcurrentRebuilds(t *testing.T) {
+	route := routeForTarget("default", "/a")
 
 	var inFlight, maxInFlight int32
 	scheme := newScheme()
@@ -164,8 +124,8 @@ func TestCoalescedRebuildNoConcurrentRebuilds(t *testing.T) {
 			return []string{obj.(*v1alpha1.CustomHTTPRoute).Spec.TargetRef.Name}
 		}).
 		WithInterceptorFuncs(interceptor.Funcs{
-			// rebuildConfigMapsForTarget begins by listing CustomHTTPRoutes;
-			// widen that window so any overlap between rebuilds is observed.
+			// rebuildConfigMapsForTarget lists CustomHTTPRoutes first; this runs
+			// inside the per-target lock, so widen it to expose any overlap.
 			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
 				if _, ok := list.(*v1alpha1.CustomHTTPRouteList); ok {
 					n := atomic.AddInt32(&inFlight, 1)
@@ -181,15 +141,28 @@ func TestCoalescedRebuildNoConcurrentRebuilds(t *testing.T) {
 				return c.List(ctx, list, opts...)
 			},
 		})
-	r := &CustomHTTPRouteReconciler{Client: cb.Build(), Scheme: scheme, ConfigMapNamespace: "test-ns"}
+	r := &CustomHTTPRouteReconciler{
+		Client:             cb.Build(),
+		Scheme:             scheme,
+		ConfigMapNamespace: "test-ns",
+		RebuildCooldown:    -1, // disabled: contention is gated only by the lock
+	}
 
 	var wg sync.WaitGroup
 	for i := 0; i < 20; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			if _, err := r.coalescedRebuildForTarget(context.Background(), "default"); err != nil {
-				t.Errorf("coalescedRebuildForTarget: %v", err)
+			for {
+				wait, err := r.rebuildTarget(context.Background(), "default", false)
+				if err != nil {
+					t.Errorf("rebuildTarget: %v", err)
+					return
+				}
+				if wait == 0 {
+					return // performed
+				}
+				// Lock was held; retry until we get our turn.
 			}
 		}()
 	}
@@ -198,8 +171,6 @@ func TestCoalescedRebuildNoConcurrentRebuilds(t *testing.T) {
 	if got := atomic.LoadInt32(&maxInFlight); got != 1 {
 		t.Fatalf("rebuilds ran concurrently: max in-flight = %d, want 1", got)
 	}
-
-	// The route's ConfigMap must still have been produced.
 	cm := &corev1.ConfigMap{}
 	if err := r.Get(context.Background(), client.ObjectKey{Name: "customrouter-routes-default-0", Namespace: "test-ns"}, cm); err != nil {
 		t.Fatalf("expected ConfigMap to be built: %v", err)

--- a/internal/controller/customhttproute/coalesce_test.go
+++ b/internal/controller/customhttproute/coalesce_test.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2024-2026 Freepik Company S.L.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package customhttproute
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"github.com/freepik-company/customrouter/api/v1alpha1"
+)
+
+// TestRebuildSingleFlightPrimitives verifies the begin/finish/release state
+// machine that drives per-target rebuild coalescing.
+func TestRebuildSingleFlightPrimitives(t *testing.T) {
+	r := &CustomHTTPRouteReconciler{}
+
+	if !r.tryBeginRebuild("t") {
+		t.Fatal("first tryBeginRebuild should take ownership")
+	}
+	// While in progress, another caller must not take ownership and must record pending.
+	if r.tryBeginRebuild("t") {
+		t.Fatal("second tryBeginRebuild should not take ownership while in progress")
+	}
+	// Owner sees the pending flag and is told to loop once more.
+	if !r.finishOrContinueRebuild("t") {
+		t.Fatal("finishOrContinueRebuild should report pending → continue")
+	}
+	// Nothing pending now → ownership released.
+	if r.finishOrContinueRebuild("t") {
+		t.Fatal("finishOrContinueRebuild should report no pending → release")
+	}
+	// Released → ownership available again.
+	if !r.tryBeginRebuild("t") {
+		t.Fatal("after release, tryBeginRebuild should take ownership again")
+	}
+	// releaseRebuild (error path) must free ownership.
+	r.releaseRebuild("t")
+	if !r.tryBeginRebuild("t") {
+		t.Fatal("after releaseRebuild, tryBeginRebuild should take ownership")
+	}
+	r.releaseRebuild("t")
+
+	// Different targets are independent.
+	if !r.tryBeginRebuild("a") || !r.tryBeginRebuild("b") {
+		t.Fatal("distinct targets must not block each other")
+	}
+}
+
+// TestCoalescedRebuildNoConcurrentRebuilds runs many concurrent
+// coalescedRebuildForTarget calls for the same target and asserts the actual
+// rebuild work never runs concurrently (which would multiply operator memory).
+func TestCoalescedRebuildNoConcurrentRebuilds(t *testing.T) {
+	route := &v1alpha1.CustomHTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "uid"},
+		Spec: v1alpha1.CustomHTTPRouteSpec{
+			Hostnames: []string{"a.example.com"},
+			TargetRef: v1alpha1.TargetRef{Name: "default"},
+			Rules: []v1alpha1.Rule{{
+				BackendRefs: []v1alpha1.BackendRef{{Name: "svc", Namespace: "ns", Port: 80}},
+				Matches:     []v1alpha1.PathMatch{{Path: "/a", Type: "Exact"}},
+			}},
+		},
+	}
+
+	var inFlight, maxInFlight int32
+	scheme := newScheme()
+	cb := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(route).
+		WithIndex(&v1alpha1.CustomHTTPRoute{}, targetRefIndexField, func(obj client.Object) []string {
+			return []string{obj.(*v1alpha1.CustomHTTPRoute).Spec.TargetRef.Name}
+		}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			// rebuildConfigMapsForTarget begins by listing CustomHTTPRoutes;
+			// widen that window so any overlap between rebuilds is observed.
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*v1alpha1.CustomHTTPRouteList); ok {
+					n := atomic.AddInt32(&inFlight, 1)
+					for {
+						m := atomic.LoadInt32(&maxInFlight)
+						if n <= m || atomic.CompareAndSwapInt32(&maxInFlight, m, n) {
+							break
+						}
+					}
+					time.Sleep(10 * time.Millisecond)
+					atomic.AddInt32(&inFlight, -1)
+				}
+				return c.List(ctx, list, opts...)
+			},
+		})
+	r := &CustomHTTPRouteReconciler{Client: cb.Build(), Scheme: scheme, ConfigMapNamespace: "test-ns"}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := r.coalescedRebuildForTarget(context.Background(), "default"); err != nil {
+				t.Errorf("coalescedRebuildForTarget: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&maxInFlight); got != 1 {
+		t.Fatalf("rebuilds ran concurrently: max in-flight = %d, want 1", got)
+	}
+
+	// The route's ConfigMap must still have been produced.
+	cm := &corev1.ConfigMap{}
+	if err := r.Get(context.Background(), client.ObjectKey{Name: "customrouter-routes-default-0", Namespace: "test-ns"}, cm); err != nil {
+		t.Fatalf("expected ConfigMap to be built: %v", err)
+	}
+}

--- a/internal/controller/customhttproute/coalesce_test.go
+++ b/internal/controller/customhttproute/coalesce_test.go
@@ -69,6 +69,44 @@ func TestRebuildSingleFlightPrimitives(t *testing.T) {
 	}
 }
 
+// TestCoalescedRebuildReportsPerformed locks the contract the reconcile relies
+// on: the call returns performed=true when it ran the rebuild and false when it
+// delegated to an in-flight owner (so the reconcile knows whether it may mark
+// the resource synced or must requeue).
+func TestCoalescedRebuildReportsPerformed(t *testing.T) {
+	route := &v1alpha1.CustomHTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "uid"},
+		Spec: v1alpha1.CustomHTTPRouteSpec{
+			Hostnames: []string{"a.example.com"},
+			TargetRef: v1alpha1.TargetRef{Name: "default"},
+			Rules: []v1alpha1.Rule{{
+				BackendRefs: []v1alpha1.BackendRef{{Name: "svc", Namespace: "ns", Port: 80}},
+				Matches:     []v1alpha1.PathMatch{{Path: "/a", Type: "Exact"}},
+			}},
+		},
+	}
+	r := newReconciler(route)
+	ctx := context.Background()
+
+	performed, err := r.coalescedRebuildForTarget(ctx, "default")
+	if err != nil || !performed {
+		t.Fatalf("owner call should perform the rebuild: performed=%v err=%v", performed, err)
+	}
+
+	// With another reconcile holding ownership, the call must delegate.
+	if !r.tryBeginRebuild("default") {
+		t.Fatal("setup: expected to take ownership")
+	}
+	performed, err = r.coalescedRebuildForTarget(ctx, "default")
+	if err != nil {
+		t.Fatalf("delegated call should not error: %v", err)
+	}
+	if performed {
+		t.Fatal("call should delegate (performed=false) while another owner is in flight")
+	}
+	r.releaseRebuild("default")
+}
+
 // TestClearTargetStateKeepsSingleFlightOwnership is the regression for the
 // empty-target path: clearTargetState runs inside rebuildConfigMapsForTarget
 // while coalescedRebuildForTarget still holds ownership, so it must NOT release
@@ -150,7 +188,7 @@ func TestCoalescedRebuildNoConcurrentRebuilds(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			if err := r.coalescedRebuildForTarget(context.Background(), "default"); err != nil {
+			if _, err := r.coalescedRebuildForTarget(context.Background(), "default"); err != nil {
 				t.Errorf("coalescedRebuildForTarget: %v", err)
 			}
 		}()

--- a/internal/controller/customhttproute/coalesce_test.go
+++ b/internal/controller/customhttproute/coalesce_test.go
@@ -106,6 +106,12 @@ func TestRebuildTargetDefers(t *testing.T) {
 	if wait, err := r2.rebuildTarget(ctx, "default", false); err != nil || wait <= 0 {
 		t.Fatalf("rebuild while lock held should defer: wait=%v err=%v", wait, err)
 	}
+	// Deletions skip the cooldown but must still honour the lock, so a deletion
+	// rebuild also defers while the lock is held (the Reconcile deletion branch
+	// then keeps the finalizer and requeues so cleanup is not lost).
+	if wait, err := r2.rebuildTarget(ctx, "default", true); err != nil || wait <= 0 {
+		t.Fatalf("deletion rebuild while lock held should defer: wait=%v err=%v", wait, err)
+	}
 	r2.targetUnlock("default")
 }
 

--- a/internal/controller/customhttproute/coalesce_test.go
+++ b/internal/controller/customhttproute/coalesce_test.go
@@ -69,6 +69,38 @@ func TestRebuildSingleFlightPrimitives(t *testing.T) {
 	}
 }
 
+// TestClearTargetStateKeepsSingleFlightOwnership is the regression for the
+// empty-target path: clearTargetState runs inside rebuildConfigMapsForTarget
+// while coalescedRebuildForTarget still holds ownership, so it must NOT release
+// the single-flight flags (doing so would let a concurrent reconcile start a
+// parallel rebuild).
+func TestClearTargetStateKeepsSingleFlightOwnership(t *testing.T) {
+	r := &CustomHTTPRouteReconciler{}
+
+	if !r.tryBeginRebuild("t") {
+		t.Fatal("setup: should take ownership")
+	}
+	// Simulate the empty-target cleanup running mid-rebuild.
+	r.clearTargetState("t")
+	// Ownership must still be held: a concurrent reconcile must not be able to
+	// begin a parallel rebuild (this call returns false and records pending).
+	if r.tryBeginRebuild("t") {
+		t.Fatal("clearTargetState must not release single-flight ownership mid-rebuild")
+	}
+	// That blocked attempt set pending, so the owner loops once...
+	if !r.finishOrContinueRebuild("t") {
+		t.Fatal("expected pending (from the blocked begin) → continue")
+	}
+	// ...then releases cleanly.
+	if r.finishOrContinueRebuild("t") {
+		t.Fatal("expected no pending → release")
+	}
+	if !r.tryBeginRebuild("t") {
+		t.Fatal("after the owner finished, ownership should be available again")
+	}
+	r.releaseRebuild("t")
+}
+
 // TestCoalescedRebuildNoConcurrentRebuilds runs many concurrent
 // coalescedRebuildForTarget calls for the same target and asserts the actual
 // rebuild work never runs concurrently (which would multiply operator memory).

--- a/internal/controller/customhttproute/controller.go
+++ b/internal/controller/customhttproute/controller.go
@@ -84,18 +84,14 @@ type CustomHTTPRouteReconciler struct {
 	partitionHashes   map[string]uint32
 	partitionHashesMu sync.Mutex
 
-	// rebuildInProgress / rebuildPending implement per-target single-flight
-	// coalescing of ConfigMap rebuilds. With MaxConcurrentReconciles>1 and many
-	// CustomHTTPRoutes sharing one target, a burst of reconciles (notably the
-	// cache resync that follows a controller restart) would otherwise run
-	// several full route-table rebuilds for the SAME target concurrently — each
-	// expands the entire route set, so N concurrent rebuilds multiply peak
-	// memory N-fold and can OOM the operator. With coalescing only one rebuild
-	// per target runs at a time; reconciles arriving while it runs set the
-	// pending flag, which triggers exactly one trailing rebuild so their changes
-	// are still captured. Guarded by rebuildMu (shared with lastRebuildAt).
-	rebuildInProgress map[string]bool
-	rebuildPending    map[string]bool
+	// rebuilding holds the set of targets with a rebuild currently running, used
+	// as a per-target single-flight lock (see targetTryLock). With
+	// MaxConcurrentReconciles>1 and many CustomHTTPRoutes sharing one target, a
+	// reconcile burst (notably the cache resync after a controller restart)
+	// would otherwise run several full route-table rebuilds for the SAME target
+	// concurrently — each expands the entire route set, so N concurrent rebuilds
+	// multiply peak memory N-fold and can OOM the operator. Guarded by rebuildMu.
+	rebuilding map[string]bool
 }
 
 // effectiveRebuildCooldown returns the cooldown to apply. A zero value falls
@@ -139,80 +135,72 @@ func (r *CustomHTTPRouteReconciler) markRebuilt(target string, when time.Time) {
 	r.lastRebuildAt[target] = when
 }
 
-// tryBeginRebuild returns true when the caller becomes the single-flight owner
-// of rebuilds for target and must perform one now. It returns false when a
-// rebuild for target is already running; in that case it records a pending
-// request so the in-flight owner performs one trailing rebuild that observes
-// the caller's change.
-func (r *CustomHTTPRouteReconciler) tryBeginRebuild(target string) bool {
+// targetTryLock acquires the exclusive per-target rebuild slot. It returns
+// false when a rebuild for target is already running. This is what bounds peak
+// memory: with MaxConcurrentReconciles>1 and many routes sharing one target, a
+// reconcile burst would otherwise run several full rebuilds of the same target
+// at once, multiplying memory N-fold (the OOM this guards against).
+func (r *CustomHTTPRouteReconciler) targetTryLock(target string) bool {
 	r.rebuildMu.Lock()
 	defer r.rebuildMu.Unlock()
-	if r.rebuildInProgress[target] {
-		if r.rebuildPending == nil {
-			r.rebuildPending = make(map[string]bool)
-		}
-		r.rebuildPending[target] = true
+	if r.rebuilding[target] {
 		return false
 	}
-	if r.rebuildInProgress == nil {
-		r.rebuildInProgress = make(map[string]bool)
+	if r.rebuilding == nil {
+		r.rebuilding = make(map[string]bool)
 	}
-	r.rebuildInProgress[target] = true
+	r.rebuilding[target] = true
 	return true
 }
 
-// finishOrContinueRebuild is called by the single-flight owner after a rebuild.
-// It returns true when another reconcile requested a rebuild while this one ran
-// (the owner should loop and rebuild once more, retaining ownership). It returns
-// false when there is nothing pending, releasing ownership.
-func (r *CustomHTTPRouteReconciler) finishOrContinueRebuild(target string) bool {
+// targetUnlock releases the per-target rebuild slot.
+func (r *CustomHTTPRouteReconciler) targetUnlock(target string) {
 	r.rebuildMu.Lock()
-	defer r.rebuildMu.Unlock()
-	if r.rebuildPending[target] {
-		r.rebuildPending[target] = false
-		return true
-	}
-	delete(r.rebuildInProgress, target)
-	delete(r.rebuildPending, target)
-	return false
-}
-
-// releaseRebuild unconditionally drops single-flight ownership for target. Used
-// on the error path so a failed rebuild does not wedge the target permanently;
-// the failing reconcile is requeued by controller-runtime and will retry.
-func (r *CustomHTTPRouteReconciler) releaseRebuild(target string) {
-	r.rebuildMu.Lock()
-	delete(r.rebuildInProgress, target)
-	delete(r.rebuildPending, target)
+	delete(r.rebuilding, target)
 	r.rebuildMu.Unlock()
 }
 
-// coalescedRebuildForTarget rebuilds a target's ConfigMaps under per-target
-// single-flight coalescing. At most one rebuild per target runs at a time, so
-// concurrent reconciles (e.g. a resync burst over many CustomHTTPRoutes sharing
-// one target) cannot multiply peak memory by running several full rebuilds at
-// once. Reconciles that arrive mid-rebuild are folded into a single trailing
-// rebuild instead of each triggering their own.
+// requeueDelay returns a positive duration to requeue after when a rebuild is
+// deferred (cooldown active or another rebuild in flight).
+func (r *CustomHTTPRouteReconciler) requeueDelay() time.Duration {
+	d := r.effectiveRebuildCooldown()
+	if d <= 0 {
+		return time.Second
+	}
+	return d
+}
+
+// rebuildTarget rebuilds a target's ConfigMaps with two guarantees:
+//   - single-flight: only one rebuild per target runs at a time (bounds memory);
+//   - rate-limited: the cooldown is re-checked INSIDE the lock so a just-finished
+//     rebuild's markRebuilt is visible, making "check cooldown + rebuild" atomic
+//     per target (the old throttle checked then rebuilt without the lock, so
+//     concurrent reconciles all passed the check and rebuilt together).
 //
-// performed reports whether this call actually ran the rebuild. It is false
-// when another reconcile already owned the rebuild: the caller's change is
-// guaranteed to be captured by the owner's (trailing) pass, but since this
-// reconcile did not itself complete a rebuild it must not yet mark the resource
-// as synced — it should requeue, mirroring the throttled path.
-func (r *CustomHTTPRouteReconciler) coalescedRebuildForTarget(ctx context.Context, target string) (performed bool, err error) {
-	if !r.tryBeginRebuild(target) {
-		return false, nil
+// It returns a non-zero requeueAfter when the rebuild was deferred (lock held by
+// another rebuild, or still in cooldown). The caller must then requeue WITHOUT
+// marking the resource synced; the change is picked up by a later reconcile's
+// rebuild, which re-lists the full current state of every route for the target —
+// so a single rebuild always captures the whole set, no trailing pass needed.
+func (r *CustomHTTPRouteReconciler) rebuildTarget(ctx context.Context, target string, deletion bool) (time.Duration, error) {
+	if !r.targetTryLock(target) {
+		return r.requeueDelay(), nil
 	}
-	for {
-		if err := r.rebuildConfigMapsForTarget(ctx, target); err != nil {
-			r.releaseRebuild(target)
-			return true, err
-		}
-		r.markRebuilt(target, time.Now())
-		if !r.finishOrContinueRebuild(target) {
-			return true, nil
+	defer r.targetUnlock(target)
+
+	// Cooldown is skipped for deletions so stale ConfigMaps/EnvoyFilters are
+	// cleaned up promptly when a route goes away.
+	if !deletion {
+		if remaining, throttled := r.rebuildWait(target, time.Now()); throttled {
+			return remaining, nil
 		}
 	}
+
+	if err := r.rebuildConfigMapsForTarget(ctx, target); err != nil {
+		return 0, err
+	}
+	r.markRebuilt(target, time.Now())
+	return 0, nil
 }
 
 // clearTargetState removes all in-memory state associated with a target that
@@ -220,13 +208,11 @@ func (r *CustomHTTPRouteReconciler) coalescedRebuildForTarget(ctx context.Contex
 // partitionHashes from growing without bound as targets are created and
 // deleted over the lifetime of the controller.
 func (r *CustomHTTPRouteReconciler) clearTargetState(target string) {
-	// NOTE: do NOT touch rebuildInProgress/rebuildPending here. clearTargetState
-	// is called from inside rebuildConfigMapsForTarget (the empty-target path),
-	// which itself runs while coalescedRebuildForTarget holds single-flight
-	// ownership. Clearing the ownership flags mid-rebuild would let a concurrent
-	// reconcile start a parallel rebuild, defeating coalescing. Those maps are
-	// self-cleaning: finishOrContinueRebuild / releaseRebuild drop their entries
-	// when the rebuild loop ends.
+	// NOTE: do NOT touch r.rebuilding here. clearTargetState is called from
+	// inside rebuildConfigMapsForTarget (the empty-target path), which runs while
+	// rebuildTarget holds the per-target lock. Releasing it here would let a
+	// concurrent reconcile start a parallel rebuild. The lock is released by
+	// rebuildTarget's deferred targetUnlock, so there is nothing to clean up.
 	r.rebuildMu.Lock()
 	delete(r.lastRebuildAt, target)
 	r.rebuildMu.Unlock()

--- a/internal/controller/customhttproute/controller.go
+++ b/internal/controller/customhttproute/controller.go
@@ -173,6 +173,7 @@ func (r *CustomHTTPRouteReconciler) finishOrContinueRebuild(target string) bool 
 		return true
 	}
 	delete(r.rebuildInProgress, target)
+	delete(r.rebuildPending, target)
 	return false
 }
 
@@ -215,10 +216,15 @@ func (r *CustomHTTPRouteReconciler) coalescedRebuildForTarget(ctx context.Contex
 // partitionHashes from growing without bound as targets are created and
 // deleted over the lifetime of the controller.
 func (r *CustomHTTPRouteReconciler) clearTargetState(target string) {
+	// NOTE: do NOT touch rebuildInProgress/rebuildPending here. clearTargetState
+	// is called from inside rebuildConfigMapsForTarget (the empty-target path),
+	// which itself runs while coalescedRebuildForTarget holds single-flight
+	// ownership. Clearing the ownership flags mid-rebuild would let a concurrent
+	// reconcile start a parallel rebuild, defeating coalescing. Those maps are
+	// self-cleaning: finishOrContinueRebuild / releaseRebuild drop their entries
+	// when the rebuild loop ends.
 	r.rebuildMu.Lock()
 	delete(r.lastRebuildAt, target)
-	delete(r.rebuildInProgress, target)
-	delete(r.rebuildPending, target)
 	r.rebuildMu.Unlock()
 
 	// Use parsePartitionName to identify entries that genuinely belong to

--- a/internal/controller/customhttproute/controller.go
+++ b/internal/controller/customhttproute/controller.go
@@ -363,6 +363,15 @@ func (r *CustomHTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 				return result, err
 			}
 
+			// If the cleanup rebuild was deferred (the per-target rebuild lock was
+			// held by another in-flight rebuild), keep the finalizer and requeue.
+			// Removing it now would let the object disappear before its routes are
+			// dropped from the target's ConfigMaps, leaving stale entries.
+			if result.RequeueAfter > 0 {
+				logger.V(1).Info("deletion cleanup deferred, keeping finalizer and requeueing", "name", req.Name)
+				return result, nil
+			}
+
 			err = controller.UpdateWithRetry(ctx, r.Client, objectManifest, func(object client.Object) error {
 				controllerutil.RemoveFinalizer(object, controller.ResourceFinalizer)
 				return nil

--- a/internal/controller/customhttproute/controller.go
+++ b/internal/controller/customhttproute/controller.go
@@ -193,20 +193,24 @@ func (r *CustomHTTPRouteReconciler) releaseRebuild(target string) {
 // one target) cannot multiply peak memory by running several full rebuilds at
 // once. Reconciles that arrive mid-rebuild are folded into a single trailing
 // rebuild instead of each triggering their own.
-func (r *CustomHTTPRouteReconciler) coalescedRebuildForTarget(ctx context.Context, target string) error {
+//
+// performed reports whether this call actually ran the rebuild. It is false
+// when another reconcile already owned the rebuild: the caller's change is
+// guaranteed to be captured by the owner's (trailing) pass, but since this
+// reconcile did not itself complete a rebuild it must not yet mark the resource
+// as synced — it should requeue, mirroring the throttled path.
+func (r *CustomHTTPRouteReconciler) coalescedRebuildForTarget(ctx context.Context, target string) (performed bool, err error) {
 	if !r.tryBeginRebuild(target) {
-		// Another reconcile owns the rebuild and will observe our change on its
-		// trailing pass; nothing more to do for the ConfigMap rebuild here.
-		return nil
+		return false, nil
 	}
 	for {
 		if err := r.rebuildConfigMapsForTarget(ctx, target); err != nil {
 			r.releaseRebuild(target)
-			return err
+			return true, err
 		}
 		r.markRebuilt(target, time.Now())
 		if !r.finishOrContinueRebuild(target) {
-			return nil
+			return true, nil
 		}
 	}
 }

--- a/internal/controller/customhttproute/controller.go
+++ b/internal/controller/customhttproute/controller.go
@@ -83,6 +83,19 @@ type CustomHTTPRouteReconciler struct {
 	// computed partition content has not changed since the last reconcile.
 	partitionHashes   map[string]uint32
 	partitionHashesMu sync.Mutex
+
+	// rebuildInProgress / rebuildPending implement per-target single-flight
+	// coalescing of ConfigMap rebuilds. With MaxConcurrentReconciles>1 and many
+	// CustomHTTPRoutes sharing one target, a burst of reconciles (notably the
+	// cache resync that follows a controller restart) would otherwise run
+	// several full route-table rebuilds for the SAME target concurrently — each
+	// expands the entire route set, so N concurrent rebuilds multiply peak
+	// memory N-fold and can OOM the operator. With coalescing only one rebuild
+	// per target runs at a time; reconciles arriving while it runs set the
+	// pending flag, which triggers exactly one trailing rebuild so their changes
+	// are still captured. Guarded by rebuildMu (shared with lastRebuildAt).
+	rebuildInProgress map[string]bool
+	rebuildPending    map[string]bool
 }
 
 // effectiveRebuildCooldown returns the cooldown to apply. A zero value falls
@@ -126,6 +139,77 @@ func (r *CustomHTTPRouteReconciler) markRebuilt(target string, when time.Time) {
 	r.lastRebuildAt[target] = when
 }
 
+// tryBeginRebuild returns true when the caller becomes the single-flight owner
+// of rebuilds for target and must perform one now. It returns false when a
+// rebuild for target is already running; in that case it records a pending
+// request so the in-flight owner performs one trailing rebuild that observes
+// the caller's change.
+func (r *CustomHTTPRouteReconciler) tryBeginRebuild(target string) bool {
+	r.rebuildMu.Lock()
+	defer r.rebuildMu.Unlock()
+	if r.rebuildInProgress[target] {
+		if r.rebuildPending == nil {
+			r.rebuildPending = make(map[string]bool)
+		}
+		r.rebuildPending[target] = true
+		return false
+	}
+	if r.rebuildInProgress == nil {
+		r.rebuildInProgress = make(map[string]bool)
+	}
+	r.rebuildInProgress[target] = true
+	return true
+}
+
+// finishOrContinueRebuild is called by the single-flight owner after a rebuild.
+// It returns true when another reconcile requested a rebuild while this one ran
+// (the owner should loop and rebuild once more, retaining ownership). It returns
+// false when there is nothing pending, releasing ownership.
+func (r *CustomHTTPRouteReconciler) finishOrContinueRebuild(target string) bool {
+	r.rebuildMu.Lock()
+	defer r.rebuildMu.Unlock()
+	if r.rebuildPending[target] {
+		r.rebuildPending[target] = false
+		return true
+	}
+	delete(r.rebuildInProgress, target)
+	return false
+}
+
+// releaseRebuild unconditionally drops single-flight ownership for target. Used
+// on the error path so a failed rebuild does not wedge the target permanently;
+// the failing reconcile is requeued by controller-runtime and will retry.
+func (r *CustomHTTPRouteReconciler) releaseRebuild(target string) {
+	r.rebuildMu.Lock()
+	delete(r.rebuildInProgress, target)
+	delete(r.rebuildPending, target)
+	r.rebuildMu.Unlock()
+}
+
+// coalescedRebuildForTarget rebuilds a target's ConfigMaps under per-target
+// single-flight coalescing. At most one rebuild per target runs at a time, so
+// concurrent reconciles (e.g. a resync burst over many CustomHTTPRoutes sharing
+// one target) cannot multiply peak memory by running several full rebuilds at
+// once. Reconciles that arrive mid-rebuild are folded into a single trailing
+// rebuild instead of each triggering their own.
+func (r *CustomHTTPRouteReconciler) coalescedRebuildForTarget(ctx context.Context, target string) error {
+	if !r.tryBeginRebuild(target) {
+		// Another reconcile owns the rebuild and will observe our change on its
+		// trailing pass; nothing more to do for the ConfigMap rebuild here.
+		return nil
+	}
+	for {
+		if err := r.rebuildConfigMapsForTarget(ctx, target); err != nil {
+			r.releaseRebuild(target)
+			return err
+		}
+		r.markRebuilt(target, time.Now())
+		if !r.finishOrContinueRebuild(target) {
+			return nil
+		}
+	}
+}
+
 // clearTargetState removes all in-memory state associated with a target that
 // no longer has any active CustomHTTPRoutes. This prevents lastRebuildAt and
 // partitionHashes from growing without bound as targets are created and
@@ -133,6 +217,8 @@ func (r *CustomHTTPRouteReconciler) markRebuilt(target string, when time.Time) {
 func (r *CustomHTTPRouteReconciler) clearTargetState(target string) {
 	r.rebuildMu.Lock()
 	delete(r.lastRebuildAt, target)
+	delete(r.rebuildInProgress, target)
+	delete(r.rebuildPending, target)
 	r.rebuildMu.Unlock()
 
 	// Use parsePartitionName to identify entries that genuinely belong to

--- a/internal/controller/customhttproute/sync.go
+++ b/internal/controller/customhttproute/sync.go
@@ -128,7 +128,12 @@ func (r *CustomHTTPRouteReconciler) ReconcileObject(
 			"name", resourceManifest.Name,
 			"previousTarget", previousTarget,
 			"newTarget", target)
-		requeueAfter, err := r.rebuildTarget(ctx, previousTarget, eventType == watch.Deleted)
+		// Treat the old-target cleanup like a deletion: skip the cooldown so the
+		// moved route is dropped from the former target promptly (a targetRef
+		// change should not leave it stale there for up to a cooldown), while
+		// still going through rebuildTarget so it honours the per-target lock and
+		// never runs concurrently with another rebuild of that target.
+		requeueAfter, err := r.rebuildTarget(ctx, previousTarget, true)
 		if err != nil {
 			return ctrl.Result{}, nil, nil, fmt.Errorf("failed to rebuild ConfigMaps for previous target %s: %w", previousTarget, err)
 		}

--- a/internal/controller/customhttproute/sync.go
+++ b/internal/controller/customhttproute/sync.go
@@ -108,18 +108,6 @@ func (r *CustomHTTPRouteReconciler) ReconcileObject(
 			"target", target)
 	}
 
-	// Cooldown: cap rebuild rate per target. Skipped for deletions so that
-	// stale ConfigMaps and EnvoyFilters are cleaned up promptly when a CR
-	// goes away.
-	if eventType != watch.Deleted {
-		if remaining, throttled := r.rebuildWait(target, time.Now()); throttled {
-			logger.V(1).Info("target rebuild in cooldown, requeueing",
-				"target", target,
-				"wait", remaining.String())
-			return ctrl.Result{RequeueAfter: remaining}, nil, nil, nil
-		}
-	}
-
 	// Snapshot current annotation state BEFORE any modifications. These are
 	// used below to detect whether catch-all / mirror / CORS axes were
 	// previously active and therefore need reconciliation even when the
@@ -128,41 +116,39 @@ func (r *CustomHTTPRouteReconciler) ReconcileObject(
 	hadMirror := resourceManifest.Annotations[hadMirrorAnnotation] == annotationValueTrue
 	hadCORS := resourceManifest.Annotations[hadCORSAnnotation] == annotationValueTrue
 
-	// If the target changed, also rebuild the old target to clean up its stale ConfigMaps
+	// If the target changed, clean up the old target first. It goes through the
+	// same single-flight + cooldown path as the current target (rebuildTarget),
+	// so it can neither run concurrently with another rebuild of that target nor
+	// bypass the rate limit. The moved route is dropped from the old target here
+	// before it is added to the new target below; if the old target is busy or
+	// in cooldown we requeue without touching the new target, so the route is
+	// never briefly present on both.
 	if previousTarget, ok := resourceManifest.Annotations[lastTargetAnnotation]; ok && previousTarget != target {
 		logger.Info("Target changed, also rebuilding previous target",
 			"name", resourceManifest.Name,
 			"previousTarget", previousTarget,
 			"newTarget", target)
-		// Rebuild the previous target synchronously (not coalesced): the moved
-		// route must be dropped from the old target's ConfigMaps before we add
-		// it to the new target below, otherwise it could briefly appear on both.
-		// Target changes are rare, so this does not affect the resync-storm
-		// memory protection the coalescing provides for the current target.
-		if err := r.rebuildConfigMapsForTarget(ctx, previousTarget); err != nil {
+		requeueAfter, err := r.rebuildTarget(ctx, previousTarget, eventType == watch.Deleted)
+		if err != nil {
 			return ctrl.Result{}, nil, nil, fmt.Errorf("failed to rebuild ConfigMaps for previous target %s: %w", previousTarget, err)
 		}
-		r.markRebuilt(previousTarget, time.Now())
+		if requeueAfter > 0 {
+			return ctrl.Result{RequeueAfter: requeueAfter}, nil, nil, nil
+		}
 	}
 
-	// Rebuild ConfigMaps for the current target (single-flight coalesced so a
-	// resync burst over many routes sharing this target cannot run several full
-	// rebuilds concurrently and multiply operator memory).
-	performed, err := r.coalescedRebuildForTarget(ctx, target)
+	// Rebuild ConfigMaps for the current target. rebuildTarget bounds memory
+	// (one rebuild per target at a time) and rate-limits via the cooldown; a
+	// non-zero wait means the rebuild was deferred (busy or in cooldown), so we
+	// requeue without marking the resource synced — the change is captured by a
+	// later reconcile's rebuild, which re-lists the full current route set.
+	requeueAfter, err := r.rebuildTarget(ctx, target, eventType == watch.Deleted)
 	if err != nil {
 		return ctrl.Result{}, nil, nil, err
 	}
-	if !performed {
-		// Another reconcile owns this target's rebuild and will capture our
-		// change on its trailing pass. Requeue instead of falling through to the
-		// status update, so ObservedGeneration/ConfigMapSynced are only set once
-		// a rebuild this reconcile completes — same contract as the throttled
-		// path above.
-		requeue := r.effectiveRebuildCooldown()
-		if requeue <= 0 {
-			requeue = time.Second
-		}
-		return ctrl.Result{RequeueAfter: requeue}, nil, nil, nil
+	if requeueAfter > 0 {
+		logger.V(1).Info("target rebuild deferred, requeueing", "target", target, "wait", requeueAfter.String())
+		return ctrl.Result{RequeueAfter: requeueAfter}, nil, nil, nil
 	}
 
 	// Reconcile catch-all / mirror / CORS EnvoyFilters when any axis is

--- a/internal/controller/customhttproute/sync.go
+++ b/internal/controller/customhttproute/sync.go
@@ -134,16 +134,35 @@ func (r *CustomHTTPRouteReconciler) ReconcileObject(
 			"name", resourceManifest.Name,
 			"previousTarget", previousTarget,
 			"newTarget", target)
-		if err := r.coalescedRebuildForTarget(ctx, previousTarget); err != nil {
+		// Rebuild the previous target synchronously (not coalesced): the moved
+		// route must be dropped from the old target's ConfigMaps before we add
+		// it to the new target below, otherwise it could briefly appear on both.
+		// Target changes are rare, so this does not affect the resync-storm
+		// memory protection the coalescing provides for the current target.
+		if err := r.rebuildConfigMapsForTarget(ctx, previousTarget); err != nil {
 			return ctrl.Result{}, nil, nil, fmt.Errorf("failed to rebuild ConfigMaps for previous target %s: %w", previousTarget, err)
 		}
+		r.markRebuilt(previousTarget, time.Now())
 	}
 
 	// Rebuild ConfigMaps for the current target (single-flight coalesced so a
 	// resync burst over many routes sharing this target cannot run several full
 	// rebuilds concurrently and multiply operator memory).
-	if err := r.coalescedRebuildForTarget(ctx, target); err != nil {
+	performed, err := r.coalescedRebuildForTarget(ctx, target)
+	if err != nil {
 		return ctrl.Result{}, nil, nil, err
+	}
+	if !performed {
+		// Another reconcile owns this target's rebuild and will capture our
+		// change on its trailing pass. Requeue instead of falling through to the
+		// status update, so ObservedGeneration/ConfigMapSynced are only set once
+		// a rebuild this reconcile completes — same contract as the throttled
+		// path above.
+		requeue := r.effectiveRebuildCooldown()
+		if requeue <= 0 {
+			requeue = time.Second
+		}
+		return ctrl.Result{RequeueAfter: requeue}, nil, nil, nil
 	}
 
 	// Reconcile catch-all / mirror / CORS EnvoyFilters when any axis is

--- a/internal/controller/customhttproute/sync.go
+++ b/internal/controller/customhttproute/sync.go
@@ -134,17 +134,17 @@ func (r *CustomHTTPRouteReconciler) ReconcileObject(
 			"name", resourceManifest.Name,
 			"previousTarget", previousTarget,
 			"newTarget", target)
-		if err := r.rebuildConfigMapsForTarget(ctx, previousTarget); err != nil {
+		if err := r.coalescedRebuildForTarget(ctx, previousTarget); err != nil {
 			return ctrl.Result{}, nil, nil, fmt.Errorf("failed to rebuild ConfigMaps for previous target %s: %w", previousTarget, err)
 		}
-		r.markRebuilt(previousTarget, time.Now())
 	}
 
-	// Rebuild ConfigMaps for the current target
-	if err := r.rebuildConfigMapsForTarget(ctx, target); err != nil {
+	// Rebuild ConfigMaps for the current target (single-flight coalesced so a
+	// resync burst over many routes sharing this target cannot run several full
+	// rebuilds concurrently and multiply operator memory).
+	if err := r.coalescedRebuildForTarget(ctx, target); err != nil {
 		return ctrl.Result{}, nil, nil, err
 	}
-	r.markRebuilt(target, time.Now())
 
 	// Reconcile catch-all / mirror / CORS EnvoyFilters when any axis is
 	// active or was previously active for this route. To avoid listing


### PR DESCRIPTION
## Síntoma
El **operator** sufre `OOMKilled` repetidos en sbx (límite 10Gi). El líder llegaba a ~8.5Gi y 5.8 cores. (El extproc está sano, no es esto.)

## Causa raíz (medida en sbx)
- Cada cambio de un `CustomHTTPRoute` dispara un rebuild **completo** de la tabla de rutas de su target.
- ~1700 CHR comparten el target `default` y `--max-concurrent-reconciles=5`.
- Una ráfaga de reconciles (sobre todo el **resync de caché tras un reinicio**) lanzaba hasta **5 rebuilds del MISMO target en paralelo**.
- El throttle no lo evita: `rebuildWait` mira el cooldown, pero `markRebuilt` se llama **después** del rebuild → los 5 reconciles concurrentes pasan el check y reconstruyen a la vez.
- Cada rebuild expande **todas** las rutas (sbx: ~847k) → N rebuilds concurrentes = N× memoria pico → OOM → reinicio → resync → OOM (bucle).

Evidencia: en reposo el operator usa ~50Mi; los 8.5Gi eran puro churn de rebuilds concurrentes/rápidos. En 10 min se loguearon **4444 reconciles / 1469 CHR distintos** (resync), con la memoria disparada.

## Fix
**Single-flight coalescing por target** (`coalescedRebuildForTarget`):
- Como mucho **un rebuild por target a la vez**.
- Los reconciles que llegan durante un rebuild marcan un flag `pending` → el dueño hace **exactamente un rebuild final** que captura sus cambios.
- Una ráfaga de resync sobre cientos de CHR se colapsa en **~1-2 rebuilds** (antes: cientos), y la memoria pico queda acotada a **un** rebuild.

Además se expone **`--rebuild-cooldown`** como flag para ajustar la frecuencia de rebuild por entorno (default sin cambios, 2s).

## Por qué es seguro
- No cambia la semántica del routing ni el contenido de los ConfigMaps (el rebuild es el mismo; solo se serializa/coalesce).
- `pending` garantiza que ningún cambio se pierde (pasada final).
- Por target: targets distintos no se bloquean entre sí; la concurrencia sigue ayudando donde aporta.

## Tests
- `coalesce_test.go`: máquina de estados begin/finish/release + **test de concurrencia** (20 goroutines) que afirma que los rebuilds **nunca solapan** (`max in-flight == 1`) y que el ConfigMap se sigue generando.
- `go build`, `go vet`, `go test ./...` y golangci-lint en verde.

## Nota
Es el análogo en el operator del fix de reload del extproc (0.7.3): "no reconstruir todo el mundo en cada evento". Tras mergear: cortar versión y desplegar en sbx; re-mediré que el operator deja de OOMear (memoria esperada: pico de ~1 rebuild, muy por debajo de 10Gi).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes reconciliation ordering, requeue timing, and deletion finalizer behavior for route ConfigMaps; semantics of written routes are unchanged but propagation can be slightly slower under churn.
> 
> **Overview**
> Fixes operator **OOM under reconcile bursts** (e.g. cache resync with many `CustomHTTPRoute` resources on one target) by ensuring **at most one full route-table rebuild per target runs at a time**, instead of several concurrent rebuilds when `max-concurrent-reconciles` > 1.
> 
> **`rebuildTarget`** acquires a per-target lock (`targetTryLock` / `rebuilding`), re-checks **rebuild cooldown inside the lock** (so concurrent reconciles no longer all pass `rebuildWait` and rebuild together), then calls `rebuildConfigMapsForTarget`. Deferred work returns **`RequeueAfter`** without marking the CR synced. **Deletions** skip cooldown but still wait on the lock; the **deletion finalizer** is kept when cleanup rebuild is deferred. **Target changes** rebuild the previous target through the same path (deletion-style cooldown skip) and requeue before touching the new target if the old rebuild is busy.
> 
> The operator exposes **`--rebuild-cooldown`** (wired from `cmd/main.go` into the reconciler); Helm documents an optional `--rebuild-cooldown=5s` arg. **`coalesce_test.go`** covers lock semantics, `clearTargetState` not releasing the lock, defer behavior, and a 20-goroutine concurrency test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 632e60717ff555221c0ff816e09912a4211ba8c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->