### PR TITLE
feat(controller): drain sibling finalizers on deletion to avoid N reb…

### DIFF
--- a/internal/controller/customhttproute/drain_test.go
+++ b/internal/controller/customhttproute/drain_test.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2024-2026 Freepik Company S.L.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package customhttproute
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/freepik-company/customrouter/api/v1alpha1"
+	"github.com/freepik-company/customrouter/internal/controller"
+)
+
+// crForDrain constructs a CustomHTTPRoute with the parameters needed by drain
+// tests. When deletionTime is non-nil the route is marked as in deletion.
+func crForDrain(name, target string, uid types.UID, deletionTime *time.Time, withFinalizer bool) *v1alpha1.CustomHTTPRoute {
+	cr := &v1alpha1.CustomHTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			UID:       uid,
+		},
+		Spec: v1alpha1.CustomHTTPRouteSpec{
+			TargetRef: v1alpha1.TargetRef{Name: target},
+		},
+	}
+	if deletionTime != nil {
+		t := metav1.NewTime(*deletionTime)
+		cr.DeletionTimestamp = &t
+	}
+	if withFinalizer {
+		cr.Finalizers = []string{controller.ResourceFinalizer}
+	}
+	return cr
+}
+
+func TestDrainSiblingsForDeletion_RemovesFinalizers(t *testing.T) {
+	now := time.Now()
+	self := crForDrain("self", "default", "uid-self", &now, true)
+	sibA := crForDrain("sib-a", "default", "uid-a", &now, true)
+	sibB := crForDrain("sib-b", "default", "uid-b", &now, true)
+	live := crForDrain("alive", "default", "uid-live", nil, true)
+
+	r := newReconciler(self, sibA, sibB, live)
+	r.drainSiblingsForDeletion(context.Background(), "default", self.UID)
+
+	if got := fetchFinalizers(t, r, "sib-a"); len(got) != 0 {
+		t.Errorf("sib-a finalizers = %v, want empty", got)
+	}
+	if got := fetchFinalizers(t, r, "sib-b"); len(got) != 0 {
+		t.Errorf("sib-b finalizers = %v, want empty", got)
+	}
+	if got := fetchFinalizers(t, r, "self"); len(got) == 0 {
+		t.Errorf("self finalizer should be untouched (Reconcile removes it later), got empty")
+	}
+	if got := fetchFinalizers(t, r, "alive"); len(got) == 0 {
+		t.Errorf("live CR finalizer should be untouched, got empty")
+	}
+}
+
+func TestDrainSiblingsForDeletion_SkipsOtherTargets(t *testing.T) {
+	now := time.Now()
+	self := crForDrain("self", "default", "uid-self", &now, true)
+	sibSameTarget := crForDrain("sib-default", "default", "uid-same", &now, true)
+	sibOtherTarget := crForDrain("sib-other", "other", "uid-other", &now, true)
+
+	r := newReconciler(self, sibSameTarget, sibOtherTarget)
+	r.drainSiblingsForDeletion(context.Background(), "default", self.UID)
+
+	if got := fetchFinalizers(t, r, "sib-default"); len(got) != 0 {
+		t.Errorf("same-target sibling should be drained, got finalizers=%v", got)
+	}
+	if got := fetchFinalizers(t, r, "sib-other"); len(got) == 0 {
+		t.Errorf("other-target sibling should NOT be drained, got empty finalizers")
+	}
+}
+
+func TestDrainSiblingsForDeletion_SkipsLiveSiblings(t *testing.T) {
+	now := time.Now()
+	self := crForDrain("self", "default", "uid-self", &now, true)
+	liveSibling := crForDrain("live", "default", "uid-live", nil, true)
+
+	r := newReconciler(self, liveSibling)
+	r.drainSiblingsForDeletion(context.Background(), "default", self.UID)
+
+	if got := fetchFinalizers(t, r, "live"); len(got) == 0 {
+		t.Errorf("live sibling should NOT be drained, got empty finalizers")
+	}
+}
+
+func TestDrainSiblingsForDeletion_SkipsSiblingsWithoutOurFinalizer(t *testing.T) {
+	now := time.Now()
+	self := crForDrain("self", "default", "uid-self", &now, true)
+	// A CR in deletion that holds only a third-party finalizer (not ours).
+	// drain must leave it untouched.
+	sibThirdParty := crForDrain("sib-third", "default", "uid-third", &now, false)
+	sibThirdParty.Finalizers = []string{"third-party/finalizer"}
+
+	r := newReconciler(self, sibThirdParty)
+	r.drainSiblingsForDeletion(context.Background(), "default", self.UID)
+
+	got := fetchFinalizers(t, r, "sib-third")
+	if len(got) != 1 || got[0] != "third-party/finalizer" {
+		t.Errorf("third-party finalizer should be untouched, got %v", got)
+	}
+}
+
+func TestDrainSiblingsForDeletion_PreservesOtherFinalizers(t *testing.T) {
+	now := time.Now()
+	self := crForDrain("self", "default", "uid-self", &now, true)
+	sib := crForDrain("sib", "default", "uid-sib", &now, true)
+	sib.Finalizers = append(sib.Finalizers, "third-party/finalizer")
+
+	r := newReconciler(self, sib)
+	r.drainSiblingsForDeletion(context.Background(), "default", self.UID)
+
+	got := fetchFinalizers(t, r, "sib")
+	if len(got) != 1 || got[0] != "third-party/finalizer" {
+		t.Errorf("expected only third-party finalizer to remain, got %v", got)
+	}
+}
+
+func TestDrainSiblingsForDeletion_IsIdempotent(t *testing.T) {
+	now := time.Now()
+	self := crForDrain("self", "default", "uid-self", &now, true)
+	sib := crForDrain("sib", "default", "uid-sib", &now, true)
+
+	r := newReconciler(self, sib)
+	ctx := context.Background()
+	r.drainSiblingsForDeletion(ctx, "default", self.UID)
+	// Second call: sibling is gone (fake client GCs after finalizers cleared).
+	// Should be a clean no-op without errors.
+	r.drainSiblingsForDeletion(ctx, "default", self.UID)
+}
+
+// fetchFinalizers reads the CR from the client and returns its finalizer list.
+// When the object has been garbage-collected (no finalizers left), the fake
+// client may either return the object with empty finalizers or NotFound; both
+// shapes are normalised to nil.
+func fetchFinalizers(t *testing.T, r *CustomHTTPRouteReconciler, name string) []string {
+	t.Helper()
+	cr := &v1alpha1.CustomHTTPRoute{}
+	err := r.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: name}, cr)
+	if err != nil {
+		// Treat NotFound as "all finalizers gone".
+		return nil
+	}
+	return cr.Finalizers
+}
+
+// Compile-time guard against unused runtime import drift.
+var _ runtime.Object = &v1alpha1.CustomHTTPRoute{}

--- a/internal/controller/customhttproute/sync.go
+++ b/internal/controller/customhttproute/sync.go
@@ -36,9 +36,11 @@ import (
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/freepik-company/customrouter/api/v1alpha1"
+	"github.com/freepik-company/customrouter/internal/controller"
 	"github.com/freepik-company/customrouter/pkg/routes"
 )
 
@@ -108,16 +110,18 @@ func (r *CustomHTTPRouteReconciler) ReconcileObject(
 			"target", target)
 	}
 
-	// Cooldown: cap rebuild rate per target. Skipped for deletions so that
-	// stale ConfigMaps and EnvoyFilters are cleaned up promptly when a CR
-	// goes away.
-	if eventType != watch.Deleted {
-		if remaining, throttled := r.rebuildWait(target, time.Now()); throttled {
-			logger.V(1).Info("target rebuild in cooldown, requeueing",
-				"target", target,
-				"wait", remaining.String())
-			return ctrl.Result{RequeueAfter: remaining}, nil, nil, nil
-		}
+	// Cooldown: cap rebuild rate per target. Applies to both Modified and
+	// Deleted events. For Deleted events the drain pattern at the end of
+	// this function removes finalizers from siblings of the same target
+	// after a single rebuild, so subsequent Deleted reconciles for the same
+	// target arrive either after the cooldown (finding the sibling already
+	// gone) or get short-circuited by the cooldown requeue — in both cases
+	// the redundant rebuild is avoided.
+	if remaining, throttled := r.rebuildWait(target, time.Now()); throttled {
+		logger.V(1).Info("target rebuild in cooldown, requeueing",
+			"target", target,
+			"wait", remaining.String())
+		return ctrl.Result{RequeueAfter: remaining}, nil, nil, nil
 	}
 
 	// Snapshot current annotation state BEFORE any modifications. These are
@@ -200,7 +204,72 @@ func (r *CustomHTTPRouteReconciler) ReconcileObject(
 		}
 	}
 
+	// Drain pattern: when a CR is being deleted, the rebuild above already
+	// reflects the absence of every sibling of the same target that is also
+	// in deletion (rebuildConfigMapsForTarget filters DeletionTimestamp).
+	// The only remaining work for those siblings is the bureaucratic
+	// finalizer removal. Doing it here avoids one full rebuild per sibling
+	// when many CRs of the same target are deleted together (e.g. namespace
+	// cascade), which would otherwise produce N redundant rebuilds.
+	if eventType == watch.Deleted {
+		r.drainSiblingsForDeletion(ctx, target, resourceManifest.UID)
+	}
+
 	return ctrl.Result{}, routeList, epaList, nil
+}
+
+// drainSiblingsForDeletion removes the controller's finalizer from every
+// other CustomHTTPRoute sharing the same target that is also marked for
+// deletion. The caller has just completed a rebuild whose output reflects
+// the absence of every such sibling, so no further reconcile work is
+// required for them. Best-effort: any individual failure is logged and the
+// sweep continues; the failed sibling will be retried by its own pending
+// reconcile.
+//
+// The current CR's finalizer is left untouched — Reconcile() removes it via
+// the existing UpdateWithRetry path after ReconcileObject returns.
+func (r *CustomHTTPRouteReconciler) drainSiblingsForDeletion(
+	ctx context.Context,
+	target string,
+	selfUID types.UID,
+) {
+	logger := log.FromContext(ctx)
+
+	var siblings v1alpha1.CustomHTTPRouteList
+	if err := r.List(ctx, &siblings, client.MatchingFields{targetRefIndexField: target}); err != nil {
+		logger.Error(err, "drain: list siblings failed", "target", target)
+		return
+	}
+
+	drained := 0
+	for i := range siblings.Items {
+		s := &siblings.Items[i]
+		if s.UID == selfUID {
+			continue
+		}
+		if s.DeletionTimestamp.IsZero() {
+			continue
+		}
+		if !controllerutil.ContainsFinalizer(s, controller.ResourceFinalizer) {
+			continue
+		}
+
+		patch := client.MergeFrom(s.DeepCopy())
+		controllerutil.RemoveFinalizer(s, controller.ResourceFinalizer)
+		if err := r.Patch(ctx, s, patch); err != nil {
+			if !errors.IsNotFound(err) {
+				logger.Error(err, "drain: patch sibling failed (will retry via own reconcile)",
+					"sibling", client.ObjectKeyFromObject(s).String())
+			}
+			continue
+		}
+		drained++
+	}
+
+	if drained > 0 {
+		logger.Info("drain: removed finalizer from sibling CRs in deletion",
+			"target", target, "drained", drained)
+	}
 }
 
 // routeHasCORSAction returns true if any rule in the route declares a cors action.


### PR DESCRIPTION
…uilds

When many CustomHTTPRoutes that share a target are deleted together, each Deleted event triggers a full ConfigMap rebuild even though every rebuild after the first reflects the same end state — rebuildConfigMapsForTarget already filters siblings in deletion.

This commit:

- Applies the per-target rebuild cooldown to Deleted events too. The drain pattern below removes finalizers from siblings after a single rebuild, so subsequent Deleted reconciles either find the sibling already gone or get short-circuited by the cooldown requeue.
- Adds drainSiblingsForDeletion: after a successful rebuild on a Deleted event, removes the controller's finalizer from every other CR sharing the same target that is also in deletion. The current CR's finalizer is left untouched and removed by the existing Reconcile path. Failures are best-effort and retried via each sibling's own pending reconcile.
- Adds drain_test.go covering finalizer removal on same-target siblings, skipping other targets, skipping live siblings, skipping siblings without our finalizer, preservation of third-party finalizers, and idempotency.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deletion/finalizer behavior for shared targets; mistakes could unblock GC too early or leave siblings stuck, though rebuild still excludes deleting routes and patches are scoped and best-effort.
> 
> **Overview**
> When a **CustomHTTPRoute** is deleted, the controller now runs **`drainSiblingsForDeletion`** after a successful per-target ConfigMap rebuild. That helper lists same-**`targetRef`** siblings that are also terminating, patches off **`controller.ResourceFinalizer`** (leaving the current object and live routes alone, and keeping any third-party finalizers), so bulk deletes (e.g. namespace teardown) do not trigger one full rebuild per sibling.
> 
> Deletion handling is wired from **`ReconcileObject`** on **`watch.Deleted`** only; patch failures are logged and skipped best-effort. **`drain_test.go`** adds unit coverage for target scoping, live siblings, finalizer filtering, and idempotency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b2b47606e62585a38e8c5940199014b4299438d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->