### PR TITLE
fix(chart): raise extproc HPA maxReplicas 10 -> 20

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -342,7 +342,7 @@ externalProcessors:
       # -- Minimum number of replicas
       minReplicas: 1
       # -- Maximum number of replicas
-      maxReplicas: 10
+      maxReplicas: 20
       # -- Metrics for autoscaling
       metrics:
         - type: Resource


### PR DESCRIPTION
extproc HPA was at 10/10 replicas with CPU 129% vs 80% target (sustained ~2.5h, no recent rollout), causing CPU throttling and correlated GRPC errors. Nodes have ~62% CPU headroom, so raise the ceiling to clear the saturation. This mathces manual change made by @rafalitox2 